### PR TITLE
Drop apt-key usage from Debian/Ubuntu instructions

### DIFF
--- a/src/asciidoc-pages/installation/linux.adoc
+++ b/src/asciidoc-pages/installation/linux.adoc
@@ -26,14 +26,14 @@ e.g temurin-17-jdk or temurin-8-jdk
 +
 [source, bash]
 ----
-sudo apt-get install -y wget apt-transport-https gnupg
+sudo apt-get install -y wget apt-transport-https
 ----
 +
 . Download the Eclipse Adoptium GPG key:
 +
 [source, bash]
 ----
-wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo apt-key add -
+wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo tee /usr/share/keyrings/adoptium.asc
 ----
 +
 . Configure the Eclipse Adoptium apt repository by replacing the values
@@ -41,7 +41,7 @@ in angle brackets:
 +
 [source, bash]
 ----
-echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | sudo tee /etc/apt/sources.list.d/adoptium.list
+echo "deb [signed-by=/usr/share/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | sudo tee /etc/apt/sources.list.d/adoptium.list
 ----
 +
 . Install the Temurin version you require:


### PR DESCRIPTION
As already suggested in
https://github.com/AdoptOpenJDK/openjdk-website/issues/960, this removes the
usage of apt-key from the Debian/Ubuntu instructions, which was lost in the
AdoptOpenJDK to Adoptium move.

This implements a pattern already used by other popular projects like
[Kubernetes](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management).
