### PR TITLE
Remove erroneous instruction from deb installation

### DIFF
--- a/src/asciidoc-pages/installation/linux.adoc
+++ b/src/asciidoc-pages/installation/linux.adoc
@@ -36,8 +36,7 @@ sudo apt-get install -y wget apt-transport-https gnupg
 wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo apt-key add -
 ----
 +
-. Configure the Eclipse Adoptium apt repository by replacing the values
-in angle brackets:
+. Configure the Eclipse Adoptium apt repository:
 +
 [source, bash]
 ----


### PR DESCRIPTION
There are no angle brackets to be replaced any more.