### PR TITLE
Revert "Bump highlight.js from 11.4.0 to 11.5.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "gatsby-transformer-asciidoc": "^3.9.0",
         "gatsby-transformer-remark": "^5.9.1",
         "gatsby-transformer-sharp": "^4.9.0",
-        "highlight.js": "^11.5.0",
+        "highlight.js": "^11.4.0",
         "i18next": "^21.6.14",
         "moment": "^2.29.1",
         "office-ui-fabric-react": "^7.183.1",
@@ -12425,9 +12425,9 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.5.0.tgz",
-      "integrity": "sha512-SM6WDj5/C+VfIY8pZ6yW6Xa0Fm1tniYVYWYW1Q/DcMnISZFrC3aQAZZZFAAZtybKNrGId3p/DNbFTtcTXXgYBw==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.4.0.tgz",
+      "integrity": "sha512-nawlpCBCSASs7EdvZOYOYVkJpGmAOKMYZgZtUqSRqodZE0GRVcFKwo1RcpeOemqh9hyttTdd5wDBwHkuSyUfnA==",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -31481,9 +31481,9 @@
       }
     },
     "highlight.js": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.5.0.tgz",
-      "integrity": "sha512-SM6WDj5/C+VfIY8pZ6yW6Xa0Fm1tniYVYWYW1Q/DcMnISZFrC3aQAZZZFAAZtybKNrGId3p/DNbFTtcTXXgYBw=="
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.4.0.tgz",
+      "integrity": "sha512-nawlpCBCSASs7EdvZOYOYVkJpGmAOKMYZgZtUqSRqodZE0GRVcFKwo1RcpeOemqh9hyttTdd5wDBwHkuSyUfnA=="
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "gatsby-transformer-asciidoc": "^3.9.0",
     "gatsby-transformer-remark": "^5.9.1",
     "gatsby-transformer-sharp": "^4.9.0",
-    "highlight.js": "^11.5.0",
+    "highlight.js": "^11.4.0",
     "i18next": "^21.6.14",
     "moment": "^2.29.1",
     "office-ui-fabric-react": "^7.183.1",


### PR DESCRIPTION
Reverts adoptium/website-v2#240

Appears to have broken the syntax highlighting...