### PR TITLE
Updates to language to help people find non-LTS JDK18

### DIFF
--- a/src/components/LatestTemurin.tsx
+++ b/src/components/LatestTemurin.tsx
@@ -63,17 +63,17 @@ const LatestTemurin = (props): JSX.Element => {
             {binary ? (
               <>
                 <a href={`/download?link=${binary.link}`} className="btn btn-lg btn-primary mt-3 py-3 text-white">
-                    <FaDownload /> Latest release
+                    <FaDownload /> Latest LTS release
                     <br/>
                     <span style={{ fontSize: '.6em'}} className="font-weight-light">{binary.release_name}</span>
                 </a>
                 <Link to="/temurin/releases" className="btn btn-outline-dark mt-3">
-                    Other platforms <FaArrowCircleRight />
+                    Other platforms and versions <FaArrowCircleRight />
                 </Link>
               </>
             ) :
               <Link to="/temurin/releases" className="btn btn-lg btn-primary mt-3 py-3 text-white">
-                  <FaDownload /> Latest releases
+                  <FaDownload /> Latest LTS releases
               </Link>
             }
             <Link to="/temurin/archive" className="btn btn-outline-dark mt-3">

--- a/src/pages/temurin/archive.js
+++ b/src/pages/temurin/archive.js
@@ -30,7 +30,7 @@ const TemurinReleases = () => (
             </div>
             <div className='btn-group'>
               <Link to='/temurin/releases' className='btn btn-primary m-3'>
-                Latest release <FaArrowCircleRight />
+                Latest releases <FaArrowCircleRight />
               </Link>
               <Link to='/temurin/nightly' className='btn btn-secondary m-3'>
                 Nightly builds <FaArrowCircleRight />

--- a/src/pages/temurin/nightly.js
+++ b/src/pages/temurin/nightly.js
@@ -30,7 +30,7 @@ const TemurinReleases = () => (
             </div>
             <div className='btn-group'>
               <Link to='/temurin/releases' className='btn btn-primary m-3'>
-                Latest release <FaArrowCircleRight />
+                Latest releases <FaArrowCircleRight />
               </Link>
               <Link to='/temurin/archive' className='btn btn-secondary m-3'>
                 Release archive <FaArrowCircleRight />

--- a/src/pages/temurin/releases.js
+++ b/src/pages/temurin/releases.js
@@ -11,11 +11,11 @@ import { loadLatestAssets } from '../../hooks'
 
 const TemurinReleases = () => (
   <Layout>
-    <Seo title='Latest release' />
+    <Seo title='Latest releases' />
     <section className='py-5 text-center container'>
       <div className='row py-lg-5'>
         <div className='col-lg-10 col-md-8 mx-auto'>
-          <h1 className='fw-light'>Latest release</h1>
+          <h1 className='fw-light'>Latest releases</h1>
           <div className='row align-items-center pt-3'>
             <div className='btn-group-vertical col-6 mx-auto'>
               <Link to='/temurin/archive' className='btn btn btn-primary mt-3'>


### PR DESCRIPTION
Following changes:
- Main download button explicitly says `Latest LTS release` instead of `Latest release` (JDK18 is our latest release)
- Link on the front page now says `Other platforms and versions` instead of just `Other platforms` in order to make it more obvious how to find the latest non-LTS release (JDK18 at the time of writing)
- The "Other platforms and versions" page is called `Latest releases` instead of `Latest release` since it allows download the latest releases of each major Temurin JDK version.

Signed-off-by: Stewart X Addison <sxa@redhat.com>