### PR TITLE
Update to the new 2 year LTS cycle

### DIFF
--- a/src/asciidoc-pages/support.adoc
+++ b/src/asciidoc-pages/support.adoc
@@ -30,11 +30,11 @@ January, April, July and October. We will follow this schedule for
 publishing binary releases from Adoptium to ensure you get the latest,
 most secure builds.
 
-In addition, every three years one feature release will be designated as
-a Long Term Supported (LTS) release. We will produce LTS releases for at
-least four years. This assurance will allow you to stay on a
-well-defined code stream, and give you time to migrate to the next, new,
-stable, LTS release when it becomes available.
+In addition, every two years after Java 17's release one feature release
+will be designated as a Long Term Supported (LTS) release. We will
+produce LTS releases for at least four years. This assurance will allow
+you to stay on a well-defined code stream, and give you time to migrate
+to the next, new, stable, LTS release when it becomes available.
 
 Based upon this roadmap, and starting with Java 8 (currently supported
 releases in bold) here is the timetable for the various releases. Note


### PR DESCRIPTION
As per OpenJDK discussions [1], it appears the release cadence has changed from an LTS every 3 years to one every 2 years starting after the release of JDK17.

[1] https://mail.openjdk.java.net/pipermail/discuss/2021-September/005945.html

Signed-off-by: Dan Heidinga <heidinga@redhat.com>