### PR TITLE
Improve YUM installer instructions

### DIFF
--- a/src/asciidoc-pages/installation/linux.adoc
+++ b/src/asciidoc-pages/installation/linux.adoc
@@ -54,8 +54,7 @@ sudo apt-get install temurin-17-jdk
 == CentOS/RHEL/Fedora Instructions
 
 . Add the RPM repo to `/etc/yum.repos.d/adoptium.repo` making sure to
-change the CentOS version if you are not using CentOS 8, and if you are
-on a 32-bit ARM system, replace `$(uname -m)` with `armv7hl`. RPMs are
+change the distribution name if you are not using CentOS. RPMs are
 also available for RHEL and Fedora. To check the full list of versions
 supported take a look at the list in the tree at
 https://packages.adoptium.net/ui/repos/tree/General after clicking the
@@ -66,7 +65,7 @@ https://packages.adoptium.net/ui/repos/tree/General after clicking the
 cat <<EOF > /etc/yum.repos.d/adoptium.repo
 [Adoptium]
 name=Adoptium
-baseurl=https://packages.adoptium.net/artifactory/rpm/centos/8/$(uname -m)
+baseurl=https://packages.adoptium.net/artifactory/rpm/centos/$releasever/$basearch
 enabled=1
 gpgcheck=1
 gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public

--- a/src/asciidoc-pages/installation/linux.adoc
+++ b/src/asciidoc-pages/installation/linux.adoc
@@ -65,7 +65,7 @@ https://packages.adoptium.net/ui/repos/tree/General after clicking the
 cat <<EOF > /etc/yum.repos.d/adoptium.repo
 [Adoptium]
 name=Adoptium
-baseurl=https://packages.adoptium.net/artifactory/rpm/centos/$releasever/$basearch
+baseurl=https://packages.adoptium.net/artifactory/rpm/centos/\$releasever/\$basearch
 enabled=1
 gpgcheck=1
 gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public


### PR DESCRIPTION
Changed YUM repo baseurl to use YUM variables instead of hard-coded version '8' and $(uname -m), the latter of which does not work as BASH does not interpret this file.  See https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/deployment_guide/sec-using_yum_variables for YUM variable info.  Also changed instructions to suit.