### PR TITLE
Update donate link to Adoptium

### DIFF
--- a/src/components/Footer/__tests__/__snapshots__/Footer.tsx.snap
+++ b/src/components/Footer/__tests__/__snapshots__/Footer.tsx.snap
@@ -52,7 +52,7 @@ exports[`DocumentationCard component renders correctly 1`] = `
             >
               <a
                 class="nav-link p-0 text-muted"
-                href="https://www.eclipse.org/donate"
+                href="https://www.eclipse.org/donate/adoptium"
               >
                 Donate
               </a>

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -26,7 +26,7 @@ const Footer = (): JSX.Element => {
               <ul className="nav flex-column">
                 <li className="nav-item mb-2"><a href="https://www.eclipse.org/org/" className="nav-link p-0 text-muted">About Us</a></li>
                 <li className="nav-item mb-2"><a href="https://www.eclipse.org/org/foundation/contact.php" className="nav-link p-0 text-muted">Contact Us</a></li>
-                <li className="nav-item mb-2"><a href="https://www.eclipse.org/donate" className="nav-link p-0 text-muted">Donate</a></li>
+                <li className="nav-item mb-2"><a href="https://www.eclipse.org/donate/adoptium" className="nav-link p-0 text-muted">Donate</a></li>
                 <li className="nav-item mb-2"><a href="https://www.eclipse.org/membership" className="nav-link p-0 text-muted">Members</a></li>
                 <li className="nav-item mb-2"><a href="https://www.eclipse.org/org/documents/" className="nav-link p-0 text-muted">Governance</a></li>
                 <li className="nav-item mb-2"><a href="https://www.eclipse.org/org/documents/Community_Code_of_Conduct.php" className="nav-link p-0 text-muted">Code of Conduct</a></li>


### PR DESCRIPTION
The new sponsor links on the repos have /adoptium appended, I assume to have funds directed to the Adoptium group. The websites footer donate is still the generic link. This PR updates it to also be /adoptium.

I don't know if it's intended to be generic though (maybe all EF project websites are required to have the generic donate in their footer) so would appreciate review :P