### PR TITLE
Add icon legends whereever the icon:: macro is used

### DIFF
--- a/src/asciidoc-pages/docs/migration/index.adoc
+++ b/src/asciidoc-pages/docs/migration/index.adoc
@@ -19,6 +19,7 @@ planned or available to replace them. Click on the links to learn more
 about each component and any steps that might be necessary to adopt
 them.
 
+icon:check[] - Supported, icon:times[] - Not Supported
 [cols="35%,25%,20%,20%",options="header",]
 |=======================================================================
 |Oracle JDK 8 proprietary component |Alternative component |OpenJDK 8 |OpenJDK 11

--- a/src/asciidoc-pages/docs/migration/index.de.adoc
+++ b/src/asciidoc-pages/docs/migration/index.de.adoc
@@ -18,6 +18,7 @@ sind, um sie zu ersetzen.
 Klicken Sie auf die Links um mehr über die einzelnen Komponenten zu erfahren und über
 die Schritte, die nötig sind um diese zu übernehmen.
 
+icon:check[] - Supported, icon:times[] - Not Supported
 [cols="35%,25%,20%,20%",options="header",]
 |=======================================================================
 |Oracle JDK 8 proprietäre Komponente |Alternative Komponente |OpenJDK 8 |OpenJDK 11

--- a/src/asciidoc-pages/supported-platforms.adoc
+++ b/src/asciidoc-pages/supported-platforms.adoc
@@ -5,8 +5,9 @@
 [lead text-muted]
 --
 This section lists the operating systems that are supported with the latest release of Eclipse Temurin.
---
 
+icon:check[] - Supported, icon:docker[] - Docker image available, icon:times[] - Not supported
+--
 [support-matrix]
 --
 [width="100%",cols="^.^5,^2,^2,^2,^2,^2",]
@@ -46,9 +47,9 @@ This section lists the operating systems that are supported with the latest rele
 | Ubuntu 20.04 | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
 
 6+h| Linux (s390x) ["data-bs-toggle="tooltip"data-bs-placement="right"title="Linux (s390x) builds should work on any distribution with glibc version 2.17 or higher."]#^[2]^#
-| RHEL 8.x | n/a ["data-bs-toggle="tooltip"data-bs-placement="right"title="JDK8 builds have no JIT so are unsupported."]#^[3]^# | icon:check[] | icon:check[] | icon:check[] | icon:check[]
-| RHEL 7.x | n/a ["data-bs-toggle="tooltip"data-bs-placement="right"title="JDK8 builds have no JIT so are unsupported."]#^[3]^# | icon:check[] | icon:check[] | icon:check[] | icon:check[]
-| Ubuntu 20.04 | n/a ["data-bs-toggle="tooltip"data-bs-placement="right"title="JDK8 builds have no JIT so are unsupported."]#^[3]^# | icon:check[] icon:docker[]  | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] 
+| RHEL 8.x | icon:times[] ["data-bs-toggle="tooltip"data-bs-placement="right"title="JDK8 builds have no JIT so are unsupported."]#^[3]^# | icon:check[] | icon:check[] | icon:check[] | icon:check[]
+| RHEL 7.x | icon:times[] ["data-bs-toggle="tooltip"data-bs-placement="right"title="JDK8 builds have no JIT so are unsupported."]#^[3]^# | icon:check[] | icon:check[] | icon:check[] | icon:check[]
+| Ubuntu 20.04 | icon:times[] ["data-bs-toggle="tooltip"data-bs-placement="right"title="JDK8 builds have no JIT so are unsupported."]#^[3]^# | icon:check[] icon:docker[]  | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] 
 
 6+h| macOS (x64) ["data-bs-toggle="tooltip"data-bs-placement="right"title="macOS builds should work on 10.12 or above."]#^[4]^#
 | macOS 11 | icon:check[] | icon:check[] | icon:check[] | icon:check[] | icon:check[]
@@ -56,11 +57,11 @@ This section lists the operating systems that are supported with the latest rele
 | macOS 10.14 | icon:check[] | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 
 6+h| macOS (Apple Silicon)
-| macOS 11 | n/a | n/a | n/a | icon:check[] | icon:check[]
+| macOS 11 | icon:times[] | icon:times[] | icon:times[] | icon:check[] | icon:check[]
 
 6+h| Solaris (x64 and Sparc)
-| Solaris 11 | icon:check[] | n/a | n/a | n/a | n/a
-| Solaris 10u11 | icon:check[] | n/a | n/a | n/a | n/a
+| Solaris 11 | icon:check[] | icon:times[] | icon:times[] | icon:times[] | icon:times[]
+| Solaris 10u11 | icon:check[] | icon:times[] | icon:times[] | icon:times[] | icon:times[]
 
 6+h| AIX (PowerPC 64-bit Big Endian)
 | AIX 7.2 | icon:check[] | icon:check[] | icon:check[] | icon:check[] | icon:check[]


### PR DESCRIPTION
Adding legend where icon macro is used.
I had problems while interpreting supported-platforms.

See issue #459 