### PR TITLE
Correctly associate label with input field

### DIFF
--- a/src/pages/slack.js
+++ b/src/pages/slack.js
@@ -28,6 +28,7 @@ const JoinPage = () => (
                 required
               />
             </label>
+            <br>
             <button
               className='btn btn-primary mt-3'
               type='submit'

--- a/src/pages/slack.js
+++ b/src/pages/slack.js
@@ -28,7 +28,7 @@ const JoinPage = () => (
                 required
               />
             </label>
-            <br>
+            <br />
             <button
               className='btn btn-primary mt-3'
               type='submit'

--- a/src/pages/slack.js
+++ b/src/pages/slack.js
@@ -18,15 +18,16 @@ const JoinPage = () => (
           target='_blank'
         >
           <div className='form-group'>
-            <label for='exampleInputEmail1'>Email address</label>
-            <input
-              autocomplete='email'
-              name='emailAddress'
-              placeholder='Your email'
-              type='email'
-              className='form-control'
-              required
-            />
+            <label>Email address
+              <input
+                autocomplete='email'
+                name='emailAddress'
+                placeholder='Your email'
+                type='email'
+                className='form-control'
+                required
+              />
+            </label>
             <button
               className='btn btn-primary mt-3'
               type='submit'


### PR DESCRIPTION
The field is not called exampleInputEmail1. Convert to nested element.
Accessibility item.