### PR TITLE
Remove sudo references in Linux installation docs

### DIFF
--- a/src/asciidoc-pages/installation/linux.adoc
+++ b/src/asciidoc-pages/installation/linux.adoc
@@ -26,29 +26,29 @@ e.g temurin-17-jdk or temurin-8-jdk
 +
 [source, bash]
 ----
-sudo apt-get install -y wget apt-transport-https
+apt-get install -y wget apt-transport-https
 ----
 +
 . Download the Eclipse Adoptium GPG key:
 +
 [source, bash]
 ----
-wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo tee /usr/share/keyrings/adoptium.asc
+wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /usr/share/keyrings/adoptium.asc
 ----
 +
 . Configure the Eclipse Adoptium apt repository:
 +
 [source, bash]
 ----
-echo "deb [signed-by=/usr/share/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | sudo tee /etc/apt/sources.list.d/adoptium.list
+echo "deb [signed-by=/usr/share/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
 ----
 +
 . Install the Temurin version you require:
 +
 [source, bash]
 ----
-sudo apt-get update # update if you haven't already
-sudo apt-get install temurin-17-jdk
+apt-get update # update if you haven't already
+apt-get install temurin-17-jdk
 ----
 
 == CentOS/RHEL/Fedora Instructions


### PR DESCRIPTION
In certain circumstances (e.g. running in a new docker container) the use of `sudo`  may not be correct and it may not even be installed. I would expect that any sysadmin would be aware of the need of when to use sudo in the appropriate circumstances. We could add something into the doc to explicitly tell users to use `sudo` but since there are other ways to attain root on many systems that may not be helpful. This also makes the Debian/Ubuntu instrucjtions consistent with the others which do not have `sudo` on the commands.