### PR TITLE
show architecture for Alpine Linux

### DIFF
--- a/src/components/TemurinArchiveTable.tsx
+++ b/src/components/TemurinArchiveTable.tsx
@@ -56,8 +56,7 @@ const TemurinArchiveTable = ({results}) => {
                                                                             <tr key={asset.checksum}>
                                                                                 <td>
                                                                                 {i === 0 &&
-                                                                                    /* Returns an "OS Arch" */
-                                                                                    `${capitalize(key.split("-")[0])} ${key.split("-")[1]}`
+                                                                                    `${capitalize(asset.os)} ${asset.architecture}`
                                                                                 }
                                                                                 </td>
                                                                                 <td>

--- a/src/components/TemurinNightlyTable.tsx
+++ b/src/components/TemurinNightlyTable.tsx
@@ -29,7 +29,7 @@ const TemurinNightlyTable = ({results}) => {
                                                 (asset, i): string | JSX.Element =>
                                                     asset && (
                                                         <tr key={asset.checksum} className="nightly-row">
-                                                            <td>{capitalize(key.split("-")[0])} {key.split("-")[1]}</td>
+                                                            <td>{capitalize(asset.os)} {asset.architecture}</td>
                                                             <td>{asset.type}</td>
                                                             <td>{moment(release.timestamp).format('D MMMM YYYY')}</td>
                                                             <td><Link to="/download" state={{ link: asset.link, os: capitalize(key.split("-")[0]), arch: key.split("-")[1], pkg_type: asset.type, java_version: 'nightly' }}>{`${asset.extension} (${asset.size} MB)`}</Link></td>

--- a/src/hooks/fetchTemurinArchive.tsx
+++ b/src/hooks/fetchTemurinArchive.tsx
@@ -64,6 +64,8 @@ function renderReleases(pkgs) {
         }
   
         let binary_constructor = {
+          os: aReleaseAsset.os,
+          architecture: aReleaseAsset.architecture,
           type: binary_type,
           link: aReleaseAsset.package.link,
           checksum: aReleaseAsset.package.checksum,

--- a/src/util/capitalize.ts
+++ b/src/util/capitalize.ts
@@ -1,6 +1,6 @@
 // Format text with a capital letter
 export function capitalize (text) {
-  if (text === 'alpine-linux') {
+  if (text.includes('alpine')) {
     return 'Alpine Linux'
   } else if (text === 'mac') {
     return 'macOS'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

currently the `split("-")` command is splitting `alpine-linux` which means that architecture is returned as `linux`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/website-v2/blob/main/CONTRIBUTING.md)
