### PR TITLE
add html/xml syntax highlighting

### DIFF
--- a/src/util/highlightCode.ts
+++ b/src/util/highlightCode.ts
@@ -8,6 +8,7 @@ import powershell from 'highlight.js/lib/languages/powershell'
 import json from 'highlight.js/lib/languages/json'
 import dos from 'highlight.js/lib/languages/dos'
 import yaml from 'highlight.js/lib/languages/yaml'
+import xml from 'highlight.js/lib/languages/xml'
 
 hljs.registerLanguage('java', java)
 hljs.registerLanguage('bash', bash)
@@ -15,6 +16,7 @@ hljs.registerLanguage('powershell', powershell)
 hljs.registerLanguage('dos', dos)
 hljs.registerLanguage('json', json)
 hljs.registerLanguage('yaml', yaml)
+hljs.registerLanguage('html', xml)
 
 export default function highlightCode () {
   const codeBlocks = document.querySelectorAll('pre > code')


### PR DESCRIPTION
Fixes the syntax highlighting on the `/temurin/buttons/` page

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/website-v2/blob/main/CONTRIBUTING.md)
