### PR TITLE
show temurin latest button on temurin page for mobile

### DIFF
--- a/src/components/LatestTemurin.tsx
+++ b/src/components/LatestTemurin.tsx
@@ -7,9 +7,9 @@ import { detectOS, UserOS } from '../util/detectOS';
 import { fetchLatestForOS, useOnScreen } from '../hooks';
 import { defaultVersion } from '../util/defaults'
 
-let userOSName
-let userOSAPIName
-let arch = 'x64'
+let userOSName: string
+let userOSAPIName: string
+let arch: string = 'x64'
 
 const LatestTemurin = (props): JSX.Element => {
 
@@ -53,7 +53,7 @@ const LatestTemurin = (props): JSX.Element => {
   }
 
     return (
-      <div ref={ref} className="container hide-on-mobile">
+      <div ref={ref} className={props.page === "home" ? "container hide-on-mobile" : "container"}>
         {binary ? (
           <h2 className={`fw-light mt-3 ${textClass}`}>Download Temurin for {userOSName} {arch}</h2>
         ) :


### PR DESCRIPTION
Currently, the latest button is hidden on mobile which makes sense on the homepage but leaves https://adoptium.net/temurin/ looking rather bare.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/website-v2/blob/main/CONTRIBUTING.md)
