### PR TITLE
santise version string in marketplace

### DIFF
--- a/src/components/MarketplaceDownloadTable.tsx
+++ b/src/components/MarketplaceDownloadTable.tsx
@@ -24,7 +24,7 @@ const DownloadTable = ({results}) => {
                         (pkg, i): string | JSX.Element =>
                             <tr key={pkg.binary.package.checksum}>
                                 <td className="table-secondary py-4 text-white align-middle w-20">
-                                    <span>{pkg.release_name}</span>
+                                    <span>{pkg.version.major}.{pkg.version.minor}.{pkg.version.security}</span>
                                     <br></br>
                                     <span>{pkg.binary.image_type == 'jdk' ? 'JDK' : 'JRE'}</span>
                                 </td>


### PR DESCRIPTION
e.g sanitises version string to be `11.0.15` for better consistency in the marketplace.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/website-v2/blob/main/CONTRIBUTING.md)
