### PR TITLE
End of service dates for Java 8 and Java 17

### DIFF
--- a/src/asciidoc-pages/support.adoc
+++ b/src/asciidoc-pages/support.adoc
@@ -52,6 +52,7 @@ short delay while we complete our extensive build and tests cycles.
 |Java 16 - Mar 2021 | jdk-16.0.2+7 - 20th Jul 2021 | EOSL^[2]^ | Sep 2021
 |Java 17 (LTS) - Sep 2021 | jdk-17.0.3+7 - 19th Apr 2022 | jdk-17.0.4 - 19th Jul 2022 | At Least Oct 2027 ^[1]^
 |Java 18 - Mar 2022 |jdk-18.0.1+10 - 19th Apr 2022 | jdk-18.0.2 - 19th Jul 2022 | Sep 2022
+|Java 19 - Sep 2022 |N/A | jdk-19 - 20th Sep 2022 | Mar 2023
 |=======================================================================
 
 ^[1]^ As a general philosophy, Adoptium will continue to build binaries

--- a/src/asciidoc-pages/support.adoc
+++ b/src/asciidoc-pages/support.adoc
@@ -47,10 +47,10 @@ short delay while we complete our extensive build and tests cycles.
 [width="100%",cols="25%,25%,25%,25%",options="header",]
 |=======================================================================
 |First Availability | Latest Release | Next Release Due | End of Availability ^[1]^
-|Java 8 (LTS) - Mar 2014 | jdk8u332 - 19th Apr 2022 | jdk8u342 - 19th Jul 2022 | At Least May 2026 ^[1]^
+|Java 8 (LTS) - Mar 2014 | jdk8u332 - 19th Apr 2022 | jdk8u342 - 19th Jul 2022 | At Least Nov 2026 ^[1]^
 |Java 11 (LTS) - Sep 2018 | jdk-11.0.15+10 - 19th Apr 2022 | jdk-11.0.16 - 19th Jul 2022 | At Least Oct 2024 ^[1]^
 |Java 16 - Mar 2021 | jdk-16.0.2+7 - 20th Jul 2021 | EOSL^[2]^ | Sep 2021
-|Java 17 (LTS) - Sep 2021 | jdk-17.0.3+7 - 19th Apr 2022 | jdk-17.0.4 - 19th Jul 2022 | TBC ^[1]^
+|Java 17 (LTS) - Sep 2021 | jdk-17.0.3+7 - 19th Apr 2022 | jdk-17.0.4 - 19th Jul 2022 | At Least Oct 2027 ^[1]^
 |Java 18 - Mar 2022 |jdk-18.0.1+10 - 19th Apr 2022 | jdk-18.0.2 - 19th Jul 2022 | Sep 2022
 |=======================================================================
 


### PR DESCRIPTION
Update the end of service dates for Temurin 8 and Temurin 17 reflecting maintainer commitments.

Awaiting PMC approval.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/website-v2/blob/main/CONTRIBUTING.md)
