### PR TITLE
Update supported linux platforms

### DIFF
--- a/src/asciidoc-pages/supported-platforms.adoc
+++ b/src/asciidoc-pages/supported-platforms.adoc
@@ -25,13 +25,13 @@ icon:check[] - Supported, icon:docker[] - Docker image available, icon:times[] -
 | Windows 8.1| icon:check[] | icon:check[] | icon:check[] | icon:check[]
 
 5+h| Linux (x64) ["data-bs-toggle="tooltip"data-bs-placement="right"title="Linux (x64) builds should work on any distribution with glibc version 2.12 or higher."]#^[1]^#
-| SUSE Linux Enterprise Server (SLES) 12 | icon:check[] | icon:check[] | icon:check[] | icon:check[]
+| Alpine Linux 3.5 or later (Headless) | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
 | RHEL / Rocky 8.x | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 | RHEL / CentOS 7.x | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
+| SUSE Linux Enterprise Server (SLES) 12 | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 | Ubuntu 22.04 | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
 | Ubuntu 20.04 | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
 | Ubuntu 18.04 | icon:check[] | icon:check[] | icon:check[] | icon:check[]
-| Alpine Linux 3.5 or later (Headless) | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
 
 5+h| Linux (ARM 64-bit) ["data-bs-toggle="tooltip"data-bs-placement="right"title="Linux (ARM 64-bit) builds should work on any distribution with glibc version 2.17 or higher."]#^[2]^#
 | RHEL / Rocky 8.x | icon:check[] | icon:check[] | icon:check[] | icon:check[]

--- a/src/asciidoc-pages/supported-platforms.adoc
+++ b/src/asciidoc-pages/supported-platforms.adoc
@@ -26,7 +26,8 @@ icon:check[] - Supported, icon:docker[] - Docker image available, icon:times[] -
 
 5+h| Linux (x64) ["data-bs-toggle="tooltip"data-bs-placement="right"title="Linux (x64) builds should work on any distribution with glibc version 2.12 or higher."]#^[1]^#
 | Alpine Linux 3.5 or later (Headless) | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
-| RHEL / Rocky 8.x | icon:check[] | icon:check[] | icon:check[] | icon:check[]
+| RHEL 9.x | icon:check[] | icon:check[] | icon:check[] | icon:check[]
+| RHEL 8.x | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 | RHEL / CentOS 7.x | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
 | SUSE Linux Enterprise Server (SLES) 12 | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 | Ubuntu 22.04 | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
@@ -34,26 +35,33 @@ icon:check[] - Supported, icon:docker[] - Docker image available, icon:times[] -
 | Ubuntu 18.04 | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 
 5+h| Linux (ARM 64-bit) ["data-bs-toggle="tooltip"data-bs-placement="right"title="Linux (ARM 64-bit) builds should work on any distribution with glibc version 2.17 or higher."]#^[2]^#
-| RHEL / Rocky 8.x | icon:check[] | icon:check[] | icon:check[] | icon:check[]
+| RHEL 9.x | icon:check[] | icon:check[] | icon:check[] | icon:check[]
+| RHEL 8.x | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 | RHEL / CentOS 7.x | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
 | Ubuntu 22.04 | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
 | Ubuntu 20.04 | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
+| Ubuntu 18.04 | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 
 5+h| Linux (ARM 32-bit Hard-Float) ["data-bs-toggle="tooltip"data-bs-placement="right"title="Linux (ARM 32-bit Hard-Float) builds should work on any distribution with glibc version 2.17 or higher."]#^[2]^#
 | Ubuntu 22.04 | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
 | Ubuntu 20.04 | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
+| Ubuntu 18.04 | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 
 5+h| Linux (PowerPC 64-bit Little Endian) ["data-bs-toggle="tooltip"data-bs-placement="right"title="Linux (PowerPC 64-bit Little Endian) builds should work on any distribution with glibc version 2.17 or higher."]#^[2]^#
-| RHEL / Rocky 8.x | icon:check[] | icon:check[] | icon:check[] | icon:check[]
-| RHEL / CentOS 7.x | icon:check[] | icon:check[] | icon:check[] | icon:check[]
+| RHEL 9.x | icon:check[] | icon:check[] | icon:check[] | icon:check[]
+| RHEL 8.x | icon:check[] | icon:check[] | icon:check[] | icon:check[]
+| RHEL / CentOS 7.x | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
 | Ubuntu 22.04 | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
 | Ubuntu 20.04 | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
+| Ubuntu 18.04 | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 
 5+h| Linux (s390x) ["data-bs-toggle="tooltip"data-bs-placement="right"title="Linux (s390x) builds should work on any distribution with glibc version 2.17 or higher."]#^[2]^#
+| RHEL 9.x | icon:times[] ["data-bs-toggle="tooltip"data-bs-placement="right"title="JDK8 builds have no JIT so are unsupported."]#^[3]^# | icon:check[] | icon:check[] | icon:check[]
 | RHEL 8.x | icon:times[] ["data-bs-toggle="tooltip"data-bs-placement="right"title="JDK8 builds have no JIT so are unsupported."]#^[3]^# | icon:check[] | icon:check[] | icon:check[]
 | RHEL 7.x | icon:times[] ["data-bs-toggle="tooltip"data-bs-placement="right"title="JDK8 builds have no JIT so are unsupported."]#^[3]^# | icon:check[] | icon:check[] | icon:check[]
-| Ubuntu 22.04 | icon:times[] ["data-bs-toggle="tooltip"data-bs-placement="right"title="JDK8 builds have no JIT so are unsupported."]#^[3]^# | icon:check[] icon:docker[]  | icon:check[] icon:docker[] | icon:check[] icon:docker[]
-| Ubuntu 20.04 | icon:times[] ["data-bs-toggle="tooltip"data-bs-placement="right"title="JDK8 builds have no JIT so are unsupported."]#^[3]^# | icon:check[] icon:docker[]  | icon:check[] icon:docker[] | icon:check[] icon:docker[]
+| Ubuntu 22.04 | icon:times[] ["data-bs-toggle="tooltip"data-bs-placement="right"title="JDK8 builds have no JIT so are unsupported."]#^[3]^# | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
+| Ubuntu 20.04 | icon:times[] ["data-bs-toggle="tooltip"data-bs-placement="right"title="JDK8 builds have no JIT so are unsupported."]#^[3]^# | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
+| Ubuntu 18.04 | icon:times[] ["data-bs-toggle="tooltip"data-bs-placement="right"title="JDK8 builds have no JIT so are unsupported."]#^[3]^# | icon:check[] | icon:check[] | icon:check[]
 
 5+h| macOS (x64) ["data-bs-toggle="tooltip"data-bs-placement="right"title="macOS builds should work on 10.12 or above."]#^[4]^#
 | macOS 12 | icon:check[] | icon:check[] | icon:check[] | icon:check[]


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->
# Updates
1. RHEL 9.x: amd64, arm64, ppc64le, s390x
    * https://hub.docker.com/r/redhat/ubi9/tags
2. SUSE Linux Enterprise Server 15: amd64, ppc64le, s390x
    * https://registry.suse.com/static/suse/sle15/index.html
3. Ubuntu 18.04: amd64, arm64/v8, arm/v7, ppc64le, s390x
    * https://hub.docker.com/_/ubuntu?tab=tags
4. CentOS 7: amd64, arm64/v8, arm/v7, ppc64le and docker image available
    * https://hub.docker.com/_/centos?tab=tags

# Remove
1. Rocky Linux 8.x from ppc64le, because not supported
    * https://rockylinux.org/download

##### Checklist#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/website-v2/blob/main/CONTRIBUTING.md)
