### PR TITLE
Update deb installation on Debian or Ubuntu

### DIFF
--- a/src/asciidoc-pages/installation/linux.adoc
+++ b/src/asciidoc-pages/installation/linux.adoc
@@ -31,29 +31,30 @@ On most Linux systems you must have superuser privileges to install packages suc
 +
 [source, bash]
 ----
-apt-get install -y wget apt-transport-https
+apt install -y wget apt-transport-https
 ----
 +
 . Download the Eclipse Adoptium GPG key:
 +
 [source, bash]
 ----
-wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /usr/share/keyrings/adoptium.asc
+mkdir -p /etc/apt/keyrings
+wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc
 ----
 +
-. Configure the Eclipse Adoptium apt repository:
+. Configure the Eclipse Adoptium apt repository. To check the full list of versions supported take a look at the list in the tree at https://packages.adoptium.net/ui/native/deb/dists/.
 +
 [source, bash]
 ----
-echo "deb [signed-by=/usr/share/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
+echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
 ----
 +
 . Install the Temurin version you require:
 +
 [source, bash]
 ----
-apt-get update # update if you haven't already
-apt-get install temurin-17-jdk
+apt update # update if you haven't already
+apt install temurin-17-jdk
 ----
 
 == CentOS/RHEL/Fedora Instructions


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->
# Changes
1. Replace `apt-get` with `apt`, because `apt` is recommended.
    * https://wiki.debian.org/DebianPackageManagement#Installing_and_removing_packages
2. Download gpg into `/etc/apt/keyrings` instead of `/usr/share/keyrings`.
    * https://wiki.debian.org/DebianRepository/UseThirdParty#OpenPGP_Key_distribution
    > If future updates to the key will be managed by an apt/dpkg package as recommended below, then it SHOULD be downloaded into /usr/share/keyrings using the same filename that will be provided by the package. If it will be managed locally , it SHOULD be downloaded into /etc/apt/keyrings instead.
    > 
    > In releases older than Debian 12 and Ubuntu 22.04, /etc/apt/keyrings does not exist by default. It SHOULD be created with permissions 0755 if it is needed and does not already exist.
3. Add a link to show all supported debian distributions.
    * https://packages.adoptium.net/ui/native/deb/dists/

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/website-v2/blob/main/CONTRIBUTING.md)
