### PR TITLE
Autoconfigure the distribution name if using CentOS/RHEL/Fedora.

### DIFF
--- a/src/asciidoc-pages/installation/linux.adoc
+++ b/src/asciidoc-pages/installation/linux.adoc
@@ -59,18 +59,17 @@ apt install temurin-17-jdk
 
 == CentOS/RHEL/Fedora Instructions
 
-. Add the RPM repo to `/etc/yum.repos.d/adoptium.repo` making sure to
-change the distribution name if you are not using CentOS. RPMs are
-also available for RHEL and Fedora. To check the full list of versions
-supported take a look at the list in the tree at
-https://packages.adoptium.net/ui/native/rpm/.
+. Add the RPM repo to `/etc/yum.repos.d/adoptium.repo` making sure to change the distribution name if you are not using CentOS/RHEL/Fedora. To check the full list of versions supported take a look at the list in the tree at https://packages.adoptium.net/ui/native/rpm/.
 +
 [source, bash]
 ----
+# Uncomment and change the distribution name if you are not using CentOS/RHEL/Fedora
+# DISTRIBUTION_NAME=centos
+
 cat <<EOF > /etc/yum.repos.d/adoptium.repo
 [Adoptium]
 name=Adoptium
-baseurl=https://packages.adoptium.net/artifactory/rpm/centos/\$releasever/\$basearch
+baseurl=https://packages.adoptium.net/artifactory/rpm/${DISTRIBUTION_NAME:-$(. /etc/os-release; echo $ID)}/\$releasever/\$basearch
 enabled=1
 gpgcheck=1
 gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public


### PR DESCRIPTION
# CentOS/RHEL/Fedora
No need to change the distribution name in `/etc/yum.repos.d/adoptium.repo`  any more.

# Other RHEL distributions
Uncomment and set `DISTRIBUTION_NAME` to rocky, oraclelinux, amazonlinux, etc. I hope it will be easier to use.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/website-v2/blob/main/CONTRIBUTING.md)
