### PR TITLE
Using dnf as the primary software management tool

### DIFF
--- a/src/asciidoc-pages/installation/linux.adoc
+++ b/src/asciidoc-pages/installation/linux.adoc
@@ -77,7 +77,14 @@ gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public
 EOF
 ----
 +
-. Install the Temurin version you require:
+. Install the Temurin version you require using `dnf`:
++
+[source, bash]
+----
+dnf update # update if you haven't already
+dnf install temurin-17-jdk
+----
+Alternatively, if you are using `yum`:
 +
 [source, bash]
 ----


### PR DESCRIPTION
1. In Red Hat Enterprise Linux 9, software installation is ensured by the DNF tool
    * https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_software_with_the_dnf_tool/con_software-management-tools-in-red-hat-enterprise-linux-9_managing-software-with-the-dnf-tool

2. DNF has been the default package manager since Fedora 22 in 2015
    * https://lists.fedoraproject.org/pipermail/announce/2015-May/003265.html

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/website-v2/blob/main/CONTRIBUTING.md)
