### PR TITLE
feat: add fallbackLange to "en"

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -33,6 +33,7 @@ module.exports = {
         localeJsonSourceName: 'locale',
         languages: ['en', 'en-GB', 'es', 'de', 'zh-CN'],
         defaultLanguage: 'en',
+        fallbackLanguage: 'en',
         i18nextOptions: {
           transSupportBasicHtmlNodes: true,
           transKeepBasicHtmlNodesFor: ['u', 'a']

--- a/locales/de/temurin.json
+++ b/locales/de/temurin.json
@@ -1,3 +1,0 @@
-{
-    "release.intro": "Eclipse Temurin is the open source Java SE build based upon OpenJDK. Temurin is available for a <supportedPlatformsLink>wide range of platforms</supportedPlatformsLink> and Java SE versions. The latest releases recommended for use in production are listed below, and are regularly <supportLink>updated and supported</supportLink> by the Adoptium community. Migration help, container images and package installation guides are available in the <docsLink>documentation section</docsLink>. You can read the <foojayLink>Release Notes</foojayLink> for each version thanks to our friends at Foojay.io!"
-}

--- a/locales/es/temurin.json
+++ b/locales/es/temurin.json
@@ -1,3 +1,0 @@
-{
-    "release.intro": "Eclipse Temurin is the open source Java SE build based upon OpenJDK. Temurin is available for a <supportedPlatformsLink>wide range of platforms</supportedPlatformsLink> and Java SE versions. The latest releases recommended for use in production are listed below, and are regularly <supportLink>updated and supported</supportLink> by the Adoptium community. Migration help, container images and package installation guides are available in the <docsLink>documentation section</docsLink>. You can read the <foojayLink>Release Notes</foojayLink> for each version thanks to our friends at Foojay.io!"
-}

--- a/src/components/LanguageSelector/index.tsx
+++ b/src/components/LanguageSelector/index.tsx
@@ -16,8 +16,8 @@ const LanguageSelector = (): JSX.Element => {
     switch(lng) {
       case 'en':
         return 'us';
-        case 'en-GB':
-          return 'gb';
+      case 'en-GB':
+        return 'gb';
       case 'zh-CN':
         return 'cn';
       default:


### PR DESCRIPTION
- Ref: https://www.gatsbyjs.com/plugins/gatsby-plugin-react-i18next/#how-to-fallback-to-a-different-language-than-the-defaultlanguage
- Ref: https://github.com/adoptium/website-v2/issues/788

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/website-v2/blob/main/CONTRIBUTING.md)
