### PR TITLE
fix search bar for docs

### DIFF
--- a/src/components/DocumentationHeader/index.tsx
+++ b/src/components/DocumentationHeader/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { convert } from 'html-to-text'
 import { useFlexSearch } from "react-use-flexsearch";
 import Autocomplete from '@mui/material/Autocomplete';
 import TextField from '@mui/material/TextField';
@@ -28,7 +29,7 @@ const DocumentationHeader = ({
       if (!results[result].path.includes('index')) {
         let item: Object = {
           id: results[result].id,
-          label: results[result].title,
+          label: convert(results[result].title),
           link: results[result].path
         }
         hintArray.push(item)


### PR DESCRIPTION
Search bar is currently showing the html code for the TM symbols

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/website-v2/blob/main/CONTRIBUTING.md)

![Screenshot 2022-08-11 at 14 26 19](https://user-images.githubusercontent.com/20224954/184143913-901c1bc9-05f9-4f56-b0f3-58122c940834.png)
