### PR TITLE
suggest aarch64 for Safari macOS users and add link to x64 download if required

### DIFF
--- a/src/components/LatestTemurin.tsx
+++ b/src/components/LatestTemurin.tsx
@@ -10,6 +10,7 @@ import { defaultVersion } from '../util/defaults'
 let userOSName: string
 let userOSAPIName: string
 let arch: string = 'x64'
+let isSafari: boolean
 
 const LatestTemurin = (props): JSX.Element => {
 
@@ -22,7 +23,9 @@ const LatestTemurin = (props): JSX.Element => {
         let w = document.createElement("canvas").getContext("webgl");
         let d = w.getExtension('WEBGL_debug_renderer_info');
         let g = d && w.getParameter(d.UNMASKED_RENDERER_WEBGL) || "";
-        if (g.match(/Apple/) && !g.match(/Apple GPU/)) {
+        isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+        //Detect if the user is using a Apple GPU (M1)
+        if (isSafari || (g.match(/Apple/) && !g.match(/Apple GPU/))) {
           arch = 'aarch64'
         }
       }
@@ -55,11 +58,19 @@ const LatestTemurin = (props): JSX.Element => {
     return (
       <div ref={ref} className={props.page === "home" ? "container hide-on-mobile" : "container"}>
         {binary ? (
+          <>
           <h2 className={`fw-light mt-3 ${textClass}`}>
             <Trans i18nKey="Download Temurin for" userOSName={userOSName} arch={arch}>
               Download Temurin&trade; for {{ userOSName }} {{ arch }}
             </Trans>
           </h2>
+          {isSafari && (
+            <span>
+              We have detected that you're using Safari. Because we are <a href="https://stackoverflow.com/a/65412357">unable to detect your architecture</a> we have suggested aarch64 (M1).
+              For x64 builds please see other <Link to="/temurin/releases">downloads</Link>.
+            </span>
+          )}
+          </>
         ) :
           <h2 className={`fw-light mt-3 ${textClass}`}>Download Temurin&trade;</h2>
         }

--- a/src/components/LatestTemurin.tsx
+++ b/src/components/LatestTemurin.tsx
@@ -66,7 +66,7 @@ const LatestTemurin = (props): JSX.Element => {
           </h2>
           {isSafari && (
             <span>
-              We have detected that you're using Safari. Because we are <a href="https://stackoverflow.com/a/65412357">unable to detect your architecture</a> we have suggested aarch64 (M1).
+              We have detected that you're using Safari. Because we are <a target="_blank" rel="noopener noreferrer" href="https://stackoverflow.com/a/65412357">unable to detect your architecture</a> we have suggested aarch64 (M1).
               For x64 builds please see other <Link to="/temurin/releases">downloads</Link>.
             </span>
           )}

--- a/src/components/LatestTemurin.tsx
+++ b/src/components/LatestTemurin.tsx
@@ -66,7 +66,7 @@ const LatestTemurin = (props): JSX.Element => {
           </h2>
           {isSafari && (
             <span>
-              We have detected that you're using Safari. Because we are <a target="_blank" rel="noopener noreferrer" href="https://stackoverflow.com/a/65412357">unable to detect your architecture</a> we have suggested aarch64 (M1).
+              We have detected that you're using Safari. Because we are <a target="_blank" rel="noopener noreferrer" href="https://stackoverflow.com/a/65412357">unable to detect your architecture</a> we have suggested aarch64 (M1/M2).
               For x64 builds please see other <Link to="/temurin/releases">downloads</Link>.
             </span>
           )}


### PR DESCRIPTION
closes: https://github.com/adoptium/website-v2/issues/908

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/website-v2/blob/main/CONTRIBUTING.md)

Adds a note to the download page for Safari users that we cannot detect their architecture and recommends aarch64 by default.

<img width="665" alt="Screenshot 2022-08-24 at 10 53 22" src="https://user-images.githubusercontent.com/20224954/186388845-d41a8484-7ad0-45af-b682-68e2be059b8d.png">

