### PR TITLE
linux installers: yum update/dnf update is not necessary

### DIFF
--- a/src/asciidoc-pages/installation/linux.adoc
+++ b/src/asciidoc-pages/installation/linux.adoc
@@ -80,14 +80,12 @@ EOF
 +
 [source, bash]
 ----
-dnf update # update if you haven't already
 dnf install temurin-17-jdk
 ----
 Alternatively, if you are using `yum`:
 +
 [source, bash]
 ----
-yum update # update if you haven't already
 yum install temurin-17-jdk
 ----
 


### PR DESCRIPTION
removes the unnecessary commands. RPM-based systems don't need to update after the repo has been added

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/website-v2/blob/main/CONTRIBUTING.md)
