### PR TITLE
doc: instruct to use --legacy-peer-deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This assumes you already have Node.js and npm installed. At time of writing we u
 1. Install your dependencies
 
     ```shell
-    npm install
+    npm install --legacy-peer-deps
     ```
 
 1. Start the site up. Gatsby will build all of the various parts of the site (Asciidoc etc). Note that this command takes some time to execute.


### PR DESCRIPTION
This is a temporary update to ensure the instructions work in the README. I believe this is timely due to new contributors from Outreachy, Hacktoberfest, etc. 

The real fix will need be to untangling the dependencies and installing them in a way where we no longer need to supply `--legacy-peer-deps`. I can open an issue for that.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/website-v2/blob/main/CONTRIBUTING.md)
