### PR TITLE
chore: add release banner for Oct 2022 CPU release

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,28 +1,28 @@
 import React from 'react';
 
 const Banner = () => {
-  return null;
+//  return null;
 
-//   return (
-//     <div className="alert text-white alert-dismissible fade show mb-0 text-center" style={{ backgroundColor: '#ff1464' }} role="alert">
-//      <strong className='p-1'>20th of September 2022:</strong>
-//         The Eclipse Temurin 19 GA Release effort has begun! You can track progress
-//         <a
-//           href="https://github.com/adoptium/adoptium/issues/170"
-//           target='_blank'
-//           rel='noopener noreferrer'
-//           className="alert-link p-1 text-white"
-//         >by platform</a> 
-//         or 
-//         <a 
-//           href="https://github.com/adoptium/adoptium/issues/171"
-//           target='_blank'
-//           rel='noopener noreferrer'
-//           className="alert-link p-1 text-white"
-//         >by detailed release checklist</a>.
-//      <button type="button" className="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-//     </div>
-//   );
+  return (
+    <div className="alert text-white alert-dismissible fade show mb-0 text-center" style={{ backgroundColor: '#ff1464' }} role="alert">
+     <strong className='p-1'>19th of October 2022:</strong>
+        We are creating the October 2022 CPU binaries for Eclipse Temurin 8u352, 11.0.17, 17.0.5 and 19.0.1
+        You can track progress
+        <a
+          href="https://github.com/adoptium/adoptium/issues/180"
+          target='_blank'
+          rel='noopener noreferrer'
+          className="alert-link p-1 text-white"
+        >by platforms</a> or 
+        <a 
+          href="https://github.com/adoptium/adoptium/issues/179"
+          target='_blank'
+          rel='noopener noreferrer'
+          className="alert-link p-1 text-white"
+        >by detailed release checklist</a>.
+     <button type="button" className="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+  );
 };
 
 export default Banner;


### PR DESCRIPTION
Add release banner for Oct 2022 CPU release
**Do not merge till 19th Oct 2022.**

Revert once release is done


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/website-v2/blob/main/CONTRIBUTING.md)
