### PR TITLE
Add link to upstream dates and our release cycle calender

### DIFF
--- a/src/asciidoc-pages/support.adoc
+++ b/src/asciidoc-pages/support.adoc
@@ -39,11 +39,17 @@ support LTS releases for at least four years. This assurance will allow
 you to stay on a well-defined code stream, and give you time to migrate
 to the next, new, stable, LTS release when it becomes available.
 
-Based upon this roadmap, here is the timetable for the various OpenJDK
-releases used to build Eclipse Temurin. Note that specific release dates
-below are from the OpenJDK source project and may not match the date the
-Adoptium project will have binaries available - there will usually be a
-short delay while we complete our extensive build and tests cycles.
+The full list of historic and future predicted OpenJDK dates can be seen at
+https://www.java.com/releases/ and you can also view our
+https://calendar.google.com/calendar/embed?src=c_56d7263c0ceda87a1678f6144426f23fb53721480b5ff71b073afb51091e5492%40group.calendar.google.com[Google Calendar]
+with our release cycles on it.
+
+Based upon this roadmap, here is the timetable showing the current release
+dates of the various OpenJDK releases used to build Eclipse Temurin.  Note
+that specific release dates below are from the OpenJDK source project and
+may not match the date the Adoptium project will have binaries available -
+there will usually be a short delay relative to these dates while we
+complete our extensive build and test cycles.
 
 [width="100%",cols="5*",options="header",]
 |===

--- a/src/asciidoc-pages/support.adoc
+++ b/src/asciidoc-pages/support.adoc
@@ -39,17 +39,17 @@ support LTS releases for at least four years. This assurance will allow
 you to stay on a well-defined code stream, and give you time to migrate
 to the next, new, stable, LTS release when it becomes available.
 
-The full list of historic and future predicted OpenJDK dates can be seen at
-https://www.java.com/releases/ and you can also view our
-https://calendar.google.com/calendar/embed?src=c_56d7263c0ceda87a1678f6144426f23fb53721480b5ff71b073afb51091e5492%40group.calendar.google.com[Google Calendar]
-with our release cycles on it.
-
 Based upon this roadmap, here is the timetable showing the current release
 dates of the various OpenJDK releases used to build Eclipse Temurin.  Note
-that specific release dates below are from the OpenJDK source project and
-may not match the date the Adoptium project will have binaries available -
-there will usually be a short delay relative to these dates while we
-complete our extensive build and test cycles.
+that the dates below are from the
+https://www.java.com/releases[upstream OpenJDK project page] and should
+not be considered the date which the Adoptium project will have binaries
+available - there will be a short delay relative to these dates while we
+complete our extensive build and test cycles which can take up to three
+weeks.  Our
+https://calendar.google.com/calendar/embed?src=c_56d7263c0ceda87a1678f6144426f23fb53721480b5ff71b073afb51091e5492%40group.calendar.google.com[Google Calendar with our release cycles] shows the expected cycle lengths for each
+of our releases.  We always prioritise the most popular platforms which
+will typically appear within a few days of these dates.
 
 [width="100%",cols="5*",options="header",]
 |===


### PR DESCRIPTION
As mentioned in the PMC meeting last week - I'm in two minds about whether to include the new google calendar cycle link (and reviews on the contents of that are also welcome!) but my personal feeling is that it's useful to have it on there so we have somewhere we can find it and to be able to point people at it when they ask why we're taking so long (i.e. we can use it as a reference to indicate that we expect it to take this amount of time.

@adoptium/adoptium-temurin-project-leads 

FYI @mbarbero since I promised you this calendar link a while back ;-)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes (`npm i` is currently failing - unrelated to this PR)
- [x] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/website-v2/blob/main/CONTRIBUTING.md)
