### PR TITLE
docs: remove link of Checklist in the Banner

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -13,13 +13,7 @@ const Banner = () => {
   //         target='_blank'
   //         rel='noopener noreferrer'
   //         className="alert-link p-1 text-white"
-  //       >by platforms</a> or 
-  //       <a 
-  //         href="https://github.com/adoptium/adoptium/issues/179"
-  //         target='_blank'
-  //         rel='noopener noreferrer'
-  //         className="alert-link p-1 text-white"
-  //       >by detailed release checklist</a>.
+  //       >by platforms</a>.
   //    <button type="button" className="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
   //   </div>
   // );


### PR DESCRIPTION
From retro https://github.com/adoptium/adoptium/issues/181#issuecomment-1308433842 we will keep having release checklist but not mark it in the banner


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/website-v2/blob/main/CONTRIBUTING.md)
