### PR TITLE
migrate remaining pages to use HEAD api

### DIFF
--- a/src/pages/__tests__/__snapshots__/asciidoc.test.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/asciidoc.test.tsx.snap
@@ -2,61 +2,6 @@
 
 exports[`Asciidoc pages > renders correctly - installation slug 1`] = `
 <main>
-  <title>
-    Asciidoc Page title | Adoptium
-  </title>
-  <meta
-    content="Sample Description"
-    name="description"
-  />
-  <meta
-    content="Asciidoc Page title | Adoptium"
-    name="og:title"
-  />
-  <meta
-    content="Sample Description"
-    name="og:description"
-  />
-  <meta
-    content="website"
-    name="og:type"
-  />
-  <meta
-    content="https://sample.com/images/social-image.png"
-    name="og:image"
-  />
-  <meta
-    content="summary_large_image"
-    name="twitter:card"
-  />
-  <meta
-    content="@adoptium"
-    name="twitter:site"
-  />
-  <meta
-    content="https://sample.com/images/social-image.png"
-    name="twitter:image"
-  />
-  <meta
-    content="@adoptium"
-    name="twitter:creator"
-  />
-  <meta
-    content="Asciidoc Page title | Adoptium"
-    name="twitter:title"
-  />
-  <meta
-    content="Sample Description"
-    name="twitter:description"
-  />
-  <link
-    href="//www.eclipse.org/eclipse.org-common/themes/solstice/public/stylesheets/vendor/cookieconsent/cookieconsent.min.css"
-    rel="stylesheet"
-    type="text/css"
-  />
-  <script
-    src="//www.eclipse.org/eclipse.org-common/themes/solstice/public/javascript/vendor/cookieconsent/default.min.js"
-  />
   <section
     class="py-5 container"
   >
@@ -461,61 +406,6 @@ exports[`Asciidoc pages > renders correctly - installation slug 1`] = `
 
 exports[`Asciidoc pages > renders correctly 1`] = `
 <main>
-  <title>
-    Asciidoc Page title | Adoptium
-  </title>
-  <meta
-    content="Sample Description"
-    name="description"
-  />
-  <meta
-    content="Asciidoc Page title | Adoptium"
-    name="og:title"
-  />
-  <meta
-    content="Sample Description"
-    name="og:description"
-  />
-  <meta
-    content="website"
-    name="og:type"
-  />
-  <meta
-    content="https://sample.com/images/social-image.png"
-    name="og:image"
-  />
-  <meta
-    content="summary_large_image"
-    name="twitter:card"
-  />
-  <meta
-    content="@adoptium"
-    name="twitter:site"
-  />
-  <meta
-    content="https://sample.com/images/social-image.png"
-    name="twitter:image"
-  />
-  <meta
-    content="@adoptium"
-    name="twitter:creator"
-  />
-  <meta
-    content="Asciidoc Page title | Adoptium"
-    name="twitter:title"
-  />
-  <meta
-    content="Sample Description"
-    name="twitter:description"
-  />
-  <link
-    href="//www.eclipse.org/eclipse.org-common/themes/solstice/public/stylesheets/vendor/cookieconsent/cookieconsent.min.css"
-    rel="stylesheet"
-    type="text/css"
-  />
-  <script
-    src="//www.eclipse.org/eclipse.org-common/themes/solstice/public/javascript/vendor/cookieconsent/default.min.js"
-  />
   <section
     class="py-5 container"
   >

--- a/src/pages/__tests__/asciidoc.test.tsx
+++ b/src/pages/__tests__/asciidoc.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render } from '@testing-library/react';
-import AllAsciidocPages from '../../templates/asciidocTemplate';
+import { render, waitFor } from '@testing-library/react';
+import AllAsciidocPages, { Head } from '../../templates/asciidocTemplate';
 import { describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe';
 import { createAsciidocData } from '../../__fixtures__/page';
@@ -14,6 +14,16 @@ describe('Asciidoc pages', () => {
     const pageContent = container.querySelector('main');
 
     expect(pageContent).toMatchSnapshot();
+  });
+
+  it('head renders correctly', () => {
+    const { container } = render(<Head data={mockData} />);
+    // eslint-disable-next-line
+    const title = container.querySelector('title');
+
+    waitFor(() => {
+      expect(title).toHaveTextContent('Asciidoc Page title | Adoptium');
+    });
   });
 
   it('renders correctly - installation slug', () => {

--- a/src/templates/asciidocTemplate.tsx
+++ b/src/templates/asciidocTemplate.tsx
@@ -13,7 +13,7 @@ import Seo from '../components/Seo'
 import '@fortawesome/fontawesome-free/css/all.min.css'
 import '@fortawesome/fontawesome-free/css/v4-shims.min.css'
 
-const AsciidocTemplate = ({ data }) =>{
+const AsciidocTemplate = ({ data }) => {
   useEffect(() => {
     asciidocFormatter()
     highlightCode()

--- a/src/templates/asciidocTemplate.tsx
+++ b/src/templates/asciidocTemplate.tsx
@@ -13,7 +13,7 @@ import Seo from '../components/Seo'
 import '@fortawesome/fontawesome-free/css/all.min.css'
 import '@fortawesome/fontawesome-free/css/v4-shims.min.css'
 
-export default function Template ({ data }) {
+const AsciidocTemplate = ({ data }) =>{
   useEffect(() => {
     asciidocFormatter()
     highlightCode()
@@ -24,7 +24,6 @@ export default function Template ({ data }) {
   const { relativePath } = file
   return (
     <Layout>
-      <Seo title={convert(document.title)} />
       <section className='py-5 container'>
         <div className='asciidoc-container container-adoc' id='asciidoc-container'>
           <div className='asciidoc'>
@@ -49,6 +48,16 @@ export default function Template ({ data }) {
     </Layout>
   )
 }
+
+export default AsciidocTemplate;
+
+export const Head = ({ data: { asciidoc: { document } } }) => {
+  return (
+    <Seo
+      title={convert(document.title)}
+    />
+  );
+};
 
 export const pageQuery = graphql`
   query($id: String!, $language: String!) {

--- a/src/templates/authorPage.tsx
+++ b/src/templates/authorPage.tsx
@@ -14,10 +14,6 @@ const AuthorPage = ({ data, pageContext }) => {
 
   return (
     <Layout>
-        <Seo
-            title={author.name}
-            description={author.summary}
-        />
         <section className='py-5 container'>
             <div className='row py-lg-5'>
                 <div className='col-lg-9 col-md-9 mx-auto'>
@@ -51,6 +47,16 @@ const AuthorPage = ({ data, pageContext }) => {
 };
 
 export default AuthorPage;
+
+export const Head = ({ pageContext }) => {
+  const author = AuthorData[pageContext.author];
+  return (
+    <Seo
+      title={author.name}
+      description={author.summary}
+    />
+  );
+};
 
 export const authorPageQuery = graphql`
   query authorPageQuery($author: String!, $limit: Int!, $language: String!) {

--- a/src/templates/blogPage.tsx
+++ b/src/templates/blogPage.tsx
@@ -9,12 +9,11 @@ import ArticlePreview from '../components/ArticlePreview';
 
 const BlogPage = ({ data, pageContext }) => {
   const posts = data.allMdx.edges;
-  const { currentPageNumber, previousPageNumber, nextPageNumber } = pageContext;
+  const { previousPageNumber, nextPageNumber } = pageContext;
   const previousPageLink = previousPageNumber === 1 ? '/blog' : `/blog/page/${previousPageNumber}`;
 
   return (
     <Layout>
-        <Seo title={`All posts – Page ${currentPageNumber}`} />
         <section className='py-5 container'>
             <div className='row py-lg-5'>
                 <div className='col-lg-9 col-md-9 mx-auto'>
@@ -70,6 +69,15 @@ const BlogPage = ({ data, pageContext }) => {
 };
 
 export default BlogPage;
+
+export const Head = ({ pageContext }) => {
+  const { currentPageNumber } = pageContext;
+  return (
+    <Seo
+      title={`All posts – Page ${currentPageNumber}`}
+    />
+  );
+};
 
 export const blogPageQuery = graphql`
   query blogPageQuery($skip: Int!, $limit: Int!, $language: String!) {

--- a/src/templates/blogPost.tsx
+++ b/src/templates/blogPost.tsx
@@ -27,19 +27,8 @@ const BlogPostTemplate = ({ data, pageContext, location, children }) => {
   const author = AuthorData[post.frontmatter.author];
   const tags = post.frontmatter.tags;
 
-  let twitterCard = '';
-
-  if (post.frontmatter && post.frontmatter.featuredImage) {
-    twitterCard = post.frontmatter.featuredImage.childImageSharp.gatsbyImageData.images.fallback.src;
-  }
-
   return (
     <Layout>
-        <Seo
-            title={post.frontmatter.title}
-            description={post.frontmatter.description || post.excerpt}
-            twitterCard={twitterCard}
-        />
         <section className='py-5 container'>
             <div className='row py-lg-5'>
                 <div className='col-lg-9 col-md-9 mx-auto'>
@@ -94,6 +83,22 @@ const BlogPostTemplate = ({ data, pageContext, location, children }) => {
 };
 
 export default BlogPostTemplate;
+
+export const Head = ({ data }) => {
+  const post = data.mdx;
+  let twitterCard = '';
+
+  if (post.frontmatter && post.frontmatter.featuredImage) {
+    twitterCard = post.frontmatter.featuredImage.childImageSharp.gatsbyImageData.images.fallback.src;
+  }
+  return (
+    <Seo
+      title={post.frontmatter.title}
+      description={post.frontmatter.description || post.excerpt}
+      twitterCard={twitterCard}
+    />
+  );
+};
 
 export const pageQuery = graphql`
   query BlogPostBySlug($slug: String!, $language: String!) {

--- a/src/templates/tagPage.tsx
+++ b/src/templates/tagPage.tsx
@@ -11,10 +11,6 @@ const Tags = ({ pageContext, data }) => {
 
   return (
     <Layout>
-        <Seo
-            title={pageContext.tag}
-            description={pageContext.tag}
-        />
         <section className='py-5 container'>
             <div className='row py-lg-5'>
                 <div className='col-lg-9 col-md-9 mx-auto'>
@@ -45,6 +41,15 @@ const Tags = ({ pageContext, data }) => {
 
 
 export default Tags;
+
+export const Head = ({ pageContext }) => {
+  return (
+    <Seo
+      title={pageContext.tag}
+      description={pageContext.tag}
+    />
+  );
+};
 
 export const tagsPageQuery = graphql`
   query tagsPageQuery($tag: String!, $language: String!) {


### PR DESCRIPTION
As per @LekoArts comments in https://github.com/adoptium/blog.adoptium.net/issues/219 we can use the HEAD API in the same way for templates

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/website-v2/blob/main/CONTRIBUTING.md)
