### PR TITLE
Added Linux Mint install hint

### DIFF
--- a/content/asciidoc-pages/installation/linux.adoc
+++ b/content/asciidoc-pages/installation/linux.adoc
@@ -48,6 +48,7 @@ wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /et
 ----
 echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
 ----
+TIP: For Linux Mint (based on Ubuntu) you have to replace `VERSION_CODENAME` with `UBUNTU_CODENAME`.
 +
 . Install the Temurin version you require:
 +


### PR DESCRIPTION
Added a tip for Linux Mint temurin installation: It is necessary to use `UBUNTU_CODENAME` instead of `VERSION_CODENAME`. For example: Linux Mint 21 contains inside `/etc/os-release` VERSION_CODENAME="vanessa" and additionally UBUNTU_CODENAME="jammy"  because  it is based on Ubuntu jammy but has its own release name (Vanessa).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

- [x] documentation is changed 
- [x] contribution guidelines followed [here](https://github.com/adoptium/website-v2/blob/main/CONTRIBUTING.md)
