### PR TITLE
Domain level redirect from blog site to path

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,12 @@ GATSBY_CONCURRENT_DOWNLOAD = "15"
 GATSBY_CPU_COUNT = "1"
 
 [[redirects]]
+  from = "https://blog.adoptium.net/*"
+  to = "https://adoptium.net/blog/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/"
   query = {variant = ":variant"}
   to = "/temurin/releases/"


### PR DESCRIPTION
Redirect URLs accessing the site via `blog.adoptium.net` to follow `adoptium.net/blog`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
