### PR TITLE
Enable OSSF badge on repo

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -12,13 +12,20 @@ jobs:
   scorecard:
     runs-on: ubuntu-latest
     permissions:
+      actions: read
+      contents: read
       security-events: write
+      id-token: write
+
     steps:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      with:
+        persist-credentials: false
     - uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d # v2.0.6
       with:
         results_file: results.sarif
         results_format: sarif
+        publish_results: true
     - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
       with:
         name: SARIF file

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Adoptium Site
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/359195e4-6832-4457-b67c-e79ddaf8c549/deploy-status)](https://app.netlify.com/sites/eclipsefdn-adoptium/deploys) [![codecov](https://codecov.io/gh/adoptium/adoptium.net/branch/main/graph/badge.svg?token=XGJMJVT8BA)](https://codecov.io/gh/adoptium/adoptium.net)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/359195e4-6832-4457-b67c-e79ddaf8c549/deploy-status)](https://app.netlify.com/sites/eclipsefdn-adoptium/deploys) [![codecov](https://codecov.io/gh/adoptium/adoptium.net/branch/main/graph/badge.svg?token=XGJMJVT8BA)](https://codecov.io/gh/adoptium/adoptium.net) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/adoptium/adoptium.net/badge)](https://api.securityscorecards.dev/projects/github.com/adoptium/adoptium.net)
 
 This repository contains the source code for [https://adoptium.net](https://adoptium.net).
 


### PR DESCRIPTION
# Description of change
Enable public results of OSSF scorecard and display as a badge on the readme file

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
