### PR TITLE
Revert to using full workflow description

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -3,13 +3,38 @@ name: OSSF Scorecard
 on:
   push:
     branches: [ main ]
-  workflow_dispatch:
+  workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
-  ossf-scorecard:
-    uses: adoptium/.github/.github/workflows/ossf-scorecard.yml@main
+  scorecard:
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
       security-events: write
       id-token: write
+
+    steps:
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      with:
+        persist-credentials: false
+    - uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d # v2.0.6
+      with:
+        results_file: results.sarif
+        results_format: sarif
+        publish_results: true
+    - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+      with:
+        name: SARIF file
+        path: results.sarif
+        retention-days: 5
+    - uses: github/codeql-action/upload-sarif@312e093a1892bd801f026f1090904ee8e460b9b6 # v2.1.34
+      with:
+        sarif_file: results.sarif


### PR DESCRIPTION
# Description of change
score-card action seems to fail for reasons unclear in the context of a `uses:` directive
## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
