### PR TITLE
Remove installation of apt-transport-https

### DIFF
--- a/content/asciidoc-pages/installation/linux.adoc
+++ b/content/asciidoc-pages/installation/linux.adoc
@@ -31,7 +31,7 @@ e.g temurin-17-jdk or temurin-8-jdk
 +
 [source, bash]
 ----
-apt install -y wget apt-transport-https
+apt install -y wget
 ----
 +
 . Download the Eclipse Adoptium GPG key:


### PR DESCRIPTION
# Description of change
`apt-transport-https` is a dummy package as of Ubuntu 18.04/Debian Buster (apt 1.5). Its functionality has been integrated into the main apt package.
- [X] documentation is changed or added (if applicable)
