### PR TITLE
Omit installation of apt-transport-https

### DIFF
--- a/content/asciidoc-pages/installation/linux.adoc
+++ b/content/asciidoc-pages/installation/linux.adoc
@@ -29,9 +29,18 @@ e.g temurin-17-jdk or temurin-8-jdk
 
 . Ensure the necessary packages are present:
 +
+For Debian 9 (Stretch)/Ubuntu 16.04 (Xenial) or older:
++
 [source, bash]
 ----
 apt install -y wget apt-transport-https
+----
++
+For Debian 10 (Buster)/Ubuntu 18.04 (Bionic) or newer:
++
+[source, bash]
+----
+apt install -y wget
 ----
 +
 . Download the Eclipse Adoptium GPG key:


### PR DESCRIPTION
# Description of change
`apt-transport-https` is a dummy package as of Debian Buster/Ubuntu 18.04 (or better: `apt` 1.5). Its functionality has been integrated into the main `apt` package.

- [X] documentation is changed or added (if applicable)
