### PR TITLE
Adding links to mission control aarch64 binaries for MacOS

### DIFF
--- a/content/asciidoc-pages/jmc/index.adoc
+++ b/content/asciidoc-pages/jmc/index.adoc
@@ -17,8 +17,11 @@ https://github.com/thegreystone/jmc-tutorial[Marcus Hirt’s tutorial].
 |Windows |{stable}
 |https://github.com/adoptium/jmc-build/releases/download/{stable}/org.openjdk.jmc-{stable}-win32.win32.x86_64.zip[org.openjdk.jmc-{stable}-win32.win32.x86_64.zip]
 
-|macOS |{stable}
+|macOS (x86_64) |{stable}
 |https://github.com/adoptium/jmc-build/releases/download/{stable}/org.openjdk.jmc-{stable}-macosx.cocoa.x86_64.tar.gz[org.openjdk.jmc-{stable}-macosx.cocoa.x86_64.tar.gz]
+
+|macOS (aarch_64) |{stable}
+|https://github.com/adoptium/jmc-build/releases/download/{stable}/org.openjdk.jmc-{stable}-macosx.cocoa.aarch64.tar.gz[org.openjdk.jmc-{stable}-macosx.cocoa.x86_64.tar.gz]
 
 |Linux |{stable}
 |https://github.com/adoptium/jmc-build/releases/download/{stable}/org.openjdk.jmc-{stable}-linux.gtk.x86_64.tar.gz[org.openjdk.jmc-{stable}-linux.gtk.x86_64.tar.gz]
@@ -32,8 +35,11 @@ https://github.com/thegreystone/jmc-tutorial[Marcus Hirt’s tutorial].
 |Windows |{snapshot}-SNAPSHOT
 |https://github.com/adoptium/jmc-build/releases/download/{snapshot}-SNAPSHOT/org.openjdk.jmc-{snapshot}-SNAPSHOT-win32.win32.x86_64.zip[org.openjdk.jmc-{snapshot}-SNAPSHOT-win32.win32.x86_64.zip]
 
-|macOS |{snapshot}-SNAPSHOT
+|macOS (x86_64) |{snapshot}-SNAPSHOT
 |https://github.com/adoptium/jmc-build/releases/download/{snapshot}-SNAPSHOT/org.openjdk.jmc-{snapshot}-SNAPSHOT-macosx.cocoa.x86_64.tar.gz[org.openjdk.jmc-{snapshot}-SNAPSHOT-macosx.cocoa.x86_64.tar.gz]
+
+|macOS (aarch_64) |{snapshot}-SNAPSHOT
+|https://github.com/adoptium/jmc-build/releases/download/{snapshot}-SNAPSHOT/org.openjdk.jmc-{snapshot}-SNAPSHOT-macosx.cocoa.x86_64.tar.gz[org.openjdk.jmc-{snapshot}-SNAPSHOT-macosx.cocoa.aarch_64.tar.gz]
 
 |Linux |{snapshot}-SNAPSHOT
 |https://github.com/adoptium/jmc-build/releases/download/{snapshot}-SNAPSHOT/org.openjdk.jmc-{snapshot}-SNAPSHOT-linux.gtk.x86_64.tar.gz[org.openjdk.jmc-{snapshot}-SNAPSHOT-linux.gtk.x86_64.tar.gz]


### PR DESCRIPTION
# Description of change

This adds the links to the binaries published for Mac M1/M2 (AArch64).

## Checklist

- [x] documentation is changed or added (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
