### PR TITLE
Change references of ci.adoptopenjdk.net to ci.adoptium.net

### DIFF
--- a/content/asciidoc-pages/docs/aqavit-verification/index.adoc
+++ b/content/asciidoc-pages/docs/aqavit-verification/index.adoc
@@ -66,7 +66,7 @@ on:
 env:  # Links to the JDK build under test and the native test libs
   USE_TESTENV_PROPERTIES: true
   BINARY_SDK: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.14.1%2B1/OpenJDK11U-jdk_x64_linux_hotspot_11.0.14.1_1.tar.gz
-  NATIVE_LIBS: https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-linux-x64-hotspot/lastSuccessfulBuild/artifact/workspace/target/OpenJDK11U-testimage_x64_linux_hotspot_2022-02-12-17-06.tar.gz
+  NATIVE_LIBS: https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-linux-x64-hotspot/lastSuccessfulBuild/artifact/workspace/target/OpenJDK11U-testimage_x64_linux_hotspot_2022-02-12-17-06.tar.gz
 
 jobs:
   run_aqa:

--- a/content/asciidoc-pages/docs/slsa/index.adoc
+++ b/content/asciidoc-pages/docs/slsa/index.adoc
@@ -24,7 +24,7 @@ All steps for producing Eclipse Temurin are defined by version-controlled
 https://github.com/adoptium/ci-jenkins-pipelines[Jenkins pipelines^] that invoke build scripts stored in the 
 https://github.com/adoptium/temurin-build[adoptium/temurin-build^]
 repository. The pipeines and build scripts are available for anyone to view and verify, and
-https://ci.adoptopenjdk.net/[the Jenkins system^]
+https://ci.adoptium.net/[the Jenkins system^]
 runs are open to scrutiny. Documentation for using the build scripts is available in the build repository's
 https://github.com/adoptium/temurin-build#readme[readme file^].
 
@@ -57,7 +57,7 @@ Each immutable revision of the code under our control has a unique reference wit
 Build - https://slsa.dev/spec/v0.1/requirements#build-service[Build service^]::
 +
 All Adoptium's build steps run on
-https://ci.adoptopenjdk.net/[our own managed Jenkins build service^] and the Eclipse Foundation's code signing service. These services perform the builds, generate the SBOMs, and build the installers where applicable. The output from the builds are uploaded to GitHub release repositories by the Jenkins CI system. No parts of the process run on a developer’s workstation.
+https://ci.adoptium.net/[our own managed Jenkins build service^] and the Eclipse Foundation's code signing service. These services perform the builds, generate the SBOMs, and build the installers where applicable. The output from the builds are uploaded to GitHub release repositories by the Jenkins CI system. No parts of the process run on a developer’s workstation.
 +
 Access to build services is carefully managed by the project. The build system is as open as possible to allow scrutiny by the community without compromising security.
 
@@ -86,7 +86,7 @@ https://www.eclipse.org/org/foundation/contact.php[addressed to the Eclipse Foun
 Build - https://slsa.dev/spec/v0.1/requirements#build-as-code[Build as code^]::
 +
 Adoptium's build definition and configuration executed by
-https://ci.adoptopenjdk.net/[the build service^]
+https://ci.adoptium.net/[the build service^]
 is verifiably derived from text file definitions stored in our version control system.
 
 

--- a/content/blog/slsa2-temurin/index.md
+++ b/content/blog/slsa2-temurin/index.md
@@ -67,7 +67,7 @@ CI server.  The requirements here are:
   [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
 
 - **Build - Build service**. All of the build steps are run using our Jenkins
-  build service (https://ci.adoptopenjdk.net) which is used to
+  build service (https://ci.adoptium.net) which is used to
   perform the builds, generate the SBOMs, and build the installers where
   applicable. The output from the builds are then posted into GitHub release
   repositories named as temurinXX-binaries (e.g.


### PR DESCRIPTION
# Description of change
See https://github.com/adoptium/infrastructure/issues/2932 for more context

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
