### PR TITLE
remove unused gatsby-plugin-gatsby-cloud package

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -257,7 +257,6 @@ module.exports = {
         display: 'standalone',
         icon: 'src/images/adoptium-icon.png' // This path is relative to the root of the site.
       }
-    },
-    'gatsby-plugin-gatsby-cloud'
+    }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "flexsearch": "^0.7.31",
         "gatsby": "^5.7.0",
         "gatsby-plugin-feed": "^5.7.0",
-        "gatsby-plugin-gatsby-cloud": "^5.7.0",
         "gatsby-plugin-google-gtag": "^5.7.0",
         "gatsby-plugin-google-tagmanager": "^5.7.0",
         "gatsby-plugin-image": "^3.7.0",
@@ -11394,40 +11393,6 @@
       }
     },
     "node_modules/gatsby-plugin-feed/node_modules/fs-extra": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/gatsby-plugin-gatsby-cloud": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-gatsby-cloud/-/gatsby-plugin-gatsby-cloud-5.7.0.tgz",
-      "integrity": "sha512-m64RfYsbIhTlfGBTTeJZQciROp9YSW9mjoxB9Jv/7LJ3pwGVcsoqnOuVTDJjnVooH6VTy6nIiAx08xzkB/yFjg==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "fs-extra": "^11.1.0",
-        "gatsby-core-utils": "^4.7.0",
-        "gatsby-telemetry": "^4.7.0",
-        "kebab-hash": "^0.1.2",
-        "lodash": "^4.17.21",
-        "webpack-assets-manifest": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "gatsby": "^5.0.0-next",
-        "webpack": "*"
-      }
-    },
-    "node_modules/gatsby-plugin-gatsby-cloud/node_modules/fs-extra": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
       "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
@@ -34191,32 +34156,6 @@
         "gatsby-plugin-utils": "^4.7.0",
         "lodash.merge": "^4.6.2",
         "rss": "^1.2.2"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        }
-      }
-    },
-    "gatsby-plugin-gatsby-cloud": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-gatsby-cloud/-/gatsby-plugin-gatsby-cloud-5.7.0.tgz",
-      "integrity": "sha512-m64RfYsbIhTlfGBTTeJZQciROp9YSW9mjoxB9Jv/7LJ3pwGVcsoqnOuVTDJjnVooH6VTy6nIiAx08xzkB/yFjg==",
-      "requires": {
-        "@babel/runtime": "^7.20.13",
-        "fs-extra": "^11.1.0",
-        "gatsby-core-utils": "^4.7.0",
-        "gatsby-telemetry": "^4.7.0",
-        "kebab-hash": "^0.1.2",
-        "lodash": "^4.17.21",
-        "webpack-assets-manifest": "^5.1.0"
       },
       "dependencies": {
         "fs-extra": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "flexsearch": "^0.7.31",
     "gatsby": "^5.7.0",
     "gatsby-plugin-feed": "^5.7.0",
-    "gatsby-plugin-gatsby-cloud": "^5.7.0",
     "gatsby-plugin-google-gtag": "^5.7.0",
     "gatsby-plugin-google-tagmanager": "^5.7.0",
     "gatsby-plugin-image": "^3.7.0",


### PR DESCRIPTION
# Description of change
We don't use gatsby cloud so there is no need to have it installed

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
