### PR TITLE
remove unused marketplaceDistributions variable

### DIFF
--- a/src/util/__tests__/defaults.test.tsx
+++ b/src/util/__tests__/defaults.test.tsx
@@ -1,4 +1,4 @@
-import { arches, defaultArchitecture, defaultPackageType, defaultVersion, marketplaceDistributions, oses, packageTypes, versions, versionsLTS } from "../defaults";
+import { arches, defaultArchitecture, defaultPackageType, defaultVersion, oses, packageTypes, versions, versionsLTS } from "../defaults";
 import { describe, expect, it } from 'vitest'
 
 describe("defaults", () => {
@@ -8,7 +8,6 @@ describe("defaults", () => {
         expect(packageTypes).toBeInstanceOf(Object);
         expect(versions).toBeInstanceOf(Object);
         expect(versionsLTS).toBeInstanceOf(Object);
-        expect(marketplaceDistributions).toBeInstanceOf(Object);
         expect(typeof defaultVersion).toBe("number");
         expect(typeof defaultPackageType).toBe("string");
         expect(typeof defaultArchitecture).toBe("string");

--- a/src/util/defaults.tsx
+++ b/src/util/defaults.tsx
@@ -6,7 +6,6 @@ export const packageTypes = ['JDK', 'JRE']
 export const versions = [20, 19, 18, 17, 16, 11, 8]
 // LTS versions only are listed here
 export const versionsLTS = [17, 11, 8]
-export const marketplaceDistributions = ['microsoft', 'temurin', 'zulu', 'semeru_certified']
 // The default JDK version to serve up on pages
 export const defaultVersion = 17
 export const defaultPackageType = 'jdk'


### PR DESCRIPTION
# Description of change

This variable was left over from an older version of the marketplace before we switched to the [JSON config file](https://github.com/adoptium/adoptium.net/blob/main/src/json/marketplace.json)

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
