### PR TITLE
Add persist-credentials: false to the updater bot

### DIFF
--- a/.github/workflows/check-contributors.yml
+++ b/.github/workflows/check-contributors.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
 
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+      with:
+        persist-credentials: false
 
     - id: files
       uses: jitterbit/get-changed-files@b17fbb00bdc0c0f63fcf166580804b4d2cdc2a42 # v1


### PR DESCRIPTION
As per the docs:

persist-credentials: false is crucial otherwise Git push is performed with github.token and not the token you configure using the env: GITHUB_TOKEN.

# Description of change
<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
