### PR TITLE
fix test warnings in DownloadDropdowns.test.tsx

### DIFF
--- a/src/components/DownloadDropdowns/__tests__/DownloadDropdowns.test.tsx
+++ b/src/components/DownloadDropdowns/__tests__/DownloadDropdowns.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, waitFor, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { act } from 'react-test-renderer';
 import { createRandomTemurinReleases } from '../../../__fixtures__/hooks';
@@ -11,7 +11,6 @@ const Table = () => {
   );
 };
 
-// Mock the VendorSelector component as this is tested separately
 vi.mock('../../VendorSelector', () => {
   return {
     default: () => <div>vendor-selector</div>,
@@ -55,57 +54,63 @@ vi.mock('query-string', () => ({
 
 describe('DownloadDropdowns component', () => {
   it('renders correctly', async () => {
-    await act(async () => {
-      const { container, getByTestId } = render(
-        <DownloadDropdowns
-          updaterAction={updater}
-          marketplace={false}
-          Table={Table}
-        />
-      );
-      waitFor(() => {
-        expect(updater).toHaveBeenCalledTimes(1);
-      }).then(async () => {
-        // Simulate a user using dropdowns
-        let select = getByTestId('os-filter');
-        act(() => {
-          fireEvent.change(select, { target: { value: 'mock_os' } });
-        });
-        expect(updater).toHaveBeenCalledTimes(2);
-        select = getByTestId('arch-filter');
-        act(() => {
-          fireEvent.change(select, { target: { value: 'mock_arch' } });
-        });
-        expect(updater).toHaveBeenCalledTimes(3);
-        select = getByTestId('package-type-filter');
-        act(() => {
-          fireEvent.change(select, { target: { value: 'any' } });
-        });
-        expect(updater).toHaveBeenCalledTimes(4);
-        select = getByTestId('version-filter');
-        act(() => {
-          fireEvent.change(select, { target: { value: 1 } });
-        });
-        expect(updater).toHaveBeenCalledTimes(5);
-        expect(container).toMatchSnapshot();
-      });
+    const { container, getByTestId } = render(
+      <DownloadDropdowns
+        updaterAction={updater}
+        marketplace={false}
+        Table={Table}
+      />
+    );
+
+    await waitFor(() => {
+      expect(updater).toHaveBeenCalledTimes(1);
     });
+
+    let select;
+
+    // Simulate a user using dropdowns
+    select = getByTestId('os-filter');
+    await act(async () => {
+      fireEvent.change(select, { target: { value: 'mock_os' } });
+    });
+
+    expect(updater).toHaveBeenCalledTimes(2);
+
+    select = getByTestId('arch-filter');
+    await act(async () => {
+      fireEvent.change(select, { target: { value: 'mock_arch' } });
+    });
+
+    expect(updater).toHaveBeenCalledTimes(3);
+
+    select = getByTestId('package-type-filter');
+    await act(async () => {
+      fireEvent.change(select, { target: { value: 'any' } });
+    });
+
+    expect(updater).toHaveBeenCalledTimes(4);
+
+    select = getByTestId('version-filter');
+    await act(async () => {
+      fireEvent.change(select, { target: { value: 1 } });
+    });
+
+    expect(updater).toHaveBeenCalledTimes(5);
+    expect(container).toMatchSnapshot();
   });
 
   it('renders correctly - marketplace', async () => {
-    await act(async () => {
-      const { container } = render(
-        <DownloadDropdowns
-          updaterAction={updater}
-          marketplace={true}
-          Table={Table}
-        />
-      );
-      waitFor(() => {
-        expect(updater).toHaveBeenCalledTimes(1);
-      }).then(() => {
-        expect(container).toMatchSnapshot();
-      });
+    const { container } = render(
+      <DownloadDropdowns
+        updaterAction={updater}
+        marketplace={true}
+        Table={Table}
+      />
+    );
+    await waitFor(() => {
+      expect(updater).toHaveBeenCalledTimes(1);
     });
+
+    expect(container).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
# Description of change
fixes the following warning:

```output
Warning: An update to DownloadDropdowns inside a test was not wrapped in act(...).

When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
    at DownloadDropdowns (/Users/gadams/adoptium.net/src/components/DownloadDropdowns/index.tsx:23:30)
Warning: An update to DownloadDropdowns inside a test was not wrapped in act(...).
```

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
