### PR TITLE
Add bot to update vitest snapshots on comment

### DIFF
--- a/.github/workflows/update_snapshot.yml
+++ b/.github/workflows/update_snapshot.yml
@@ -1,0 +1,49 @@
+name: Update Vitest Snapshots
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  update-snapshots:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.comment.body, '/update-snapshot')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.2
+        with:
+          ref: ${{ github.event.issue.head_ref }}
+          repository: ${{ github.event.issue.repository.full_name }}
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c #v3.6.0
+        with:
+          node-version: '18'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Update Vitest Snapshots
+        run: npm test -- -u
+
+      - name: Commit and push changes
+        run: |
+          git config --global user.name "GitHub Action"
+          git config --global user.email "action@github.com"
+          git add .
+          if git diff-index --quiet HEAD; then
+            echo "NO_CHANGES_DETECTED=1" >> $GITHUB_ENV
+          else
+            git commit -m "Update Vitest Snapshots"
+            git push
+          fi
+
+      - name: Add comment
+        uses: peter-evans/create-or-update-comment@5f5d3f3db80d1b8f5130b14658b3c1aa3e3a3770 #v1.4.5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            ${{ env.NO_CHANGES_DETECTED == '1' && 'No snapshot changes detected.' || 'Snapshots updated and changes pushed to the PR.' }}

--- a/.github/workflows/update_snapshot.yml
+++ b/.github/workflows/update_snapshot.yml
@@ -10,14 +10,14 @@ jobs:
     if: startsWith(github.event.comment.body, '/update-snapshot')
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.2
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           ref: ${{ github.event.issue.head_ref }}
           repository: ${{ github.event.issue.repository.full_name }}
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c #v3.6.0
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
           node-version: '18'
           cache: npm
@@ -41,7 +41,7 @@ jobs:
           fi
 
       - name: Add comment
-        uses: peter-evans/create-or-update-comment@5f5d3f3db80d1b8f5130b14658b3c1aa3e3a3770 #v1.4.5
+        uses: peter-evans/create-or-update-comment@ca08ebd5dc95aa0cd97021e9708fcd6b87138c9b # v3.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/update_snapshot.yml
+++ b/.github/workflows/update_snapshot.yml
@@ -34,7 +34,7 @@ jobs:
           git config --global user.email "action@github.com"
           git add .
           if git diff-index --quiet HEAD; then
-            echo "NO_CHANGES_DETECTED=1" >> $GITHUB_ENV
+            echo "NO_CHANGES_DETECTED=1" >> "${GITHUB_ENV}"
           else
             git commit -m "Update Vitest Snapshots"
             git push


### PR DESCRIPTION
# Description of change

This workflow allows users to comment `/update-snapshot` on a pull request and a job will automatically push any snapshot change to the pull request

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
