### PR TITLE
Pick up Java version numbers from API rather than hard coding

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,4 +1,6 @@
+const crypto = require('crypto')
 const path = require('path')
+const fetch = require('node-fetch')
 const fs = require('fs')
 const { pipeline } = require('stream')
 const { promisify } = require('util')
@@ -7,6 +9,64 @@ const locales = require('./locales/i18n')
 const authors = require('./src/json/authors.json')
 
 const { localizedSlug, findKey, removeTrailingSlash } = require('./src/util/gatsby-node-helpers')
+
+// Import available versions from Adoptium API
+exports.sourceNodes = async ({ actions, createNodeId }) => {
+  const { createNode } = actions;
+
+  // Fetch available versions from Adoptium API
+  const res = await fetch('https://api.adoptium.net/v3/info/available_releases');
+  const data = await res.json();
+
+  data.available_releases.forEach((release, i) => {
+    const nodeContent = JSON.stringify(release);
+
+    const nodeMeta = {
+      id: createNodeId(`adoptium-release-${i}`), // Unique identifier for each node
+      parent: null,
+      children: [],
+      internal: {
+        type: 'Versions',
+        content: nodeContent,
+        contentDigest: crypto
+          .createHash('md5')
+          .update(nodeContent)
+          .digest('hex')
+      }
+    };
+
+    const lts = data.available_lts_releases.includes(release);
+
+    const extraData = {
+      version: release,
+      lts: lts,
+      label: lts ? `${release} - LTS` : release.toString()
+    };
+
+    // Combine the metadata and data to create the node
+    const node = Object.assign({}, extraData, nodeMeta);
+    createNode(node);
+  });
+
+  // Create a node for the most recent LTS release
+  const most_recent_lts = data.most_recent_lts;
+  const nodeContent = JSON.stringify(most_recent_lts);
+  const node = {
+    id: createNodeId(`adoptium-lts-most-recent`), // Unique identifier for each node
+    version: most_recent_lts,
+    parent: null,
+    children: [],
+    internal: {
+      type: 'MostRecentLTS',
+      content: nodeContent,
+      contentDigest: crypto
+        .createHash('md5')
+        .update(nodeContent)
+        .digest('hex')
+    }
+  };
+  createNode(node);
+};
 
 exports.onCreatePage = ({ page, actions }) => {
   const { createPage, deletePage } = actions

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -12,14 +12,14 @@ const { localizedSlug, findKey, removeTrailingSlash } = require('./src/util/gats
 
 // Import available versions from Adoptium API
 exports.sourceNodes = async ({ actions, createNodeId }) => {
-  const { createNode } = actions;
+  const { createNode } = actions
 
   // Fetch available versions from Adoptium API
-  const res = await fetch('https://api.adoptium.net/v3/info/available_releases');
-  const data = await res.json();
+  const res = await fetch('https://api.adoptium.net/v3/info/available_releases')
+  const data = await res.json()
 
   data.available_releases.forEach((release, i) => {
-    const nodeContent = JSON.stringify(release);
+    const nodeContent = JSON.stringify(release)
 
     const nodeMeta = {
       id: createNodeId(`adoptium-release-${i}`), // Unique identifier for each node
@@ -33,27 +33,27 @@ exports.sourceNodes = async ({ actions, createNodeId }) => {
           .update(nodeContent)
           .digest('hex')
       }
-    };
+    }
 
-    const lts = data.available_lts_releases.includes(release);
+    const lts = data.available_lts_releases.includes(release)
 
     const extraData = {
       version: release,
-      lts: lts,
+      lts,
       label: lts ? `${release} - LTS` : release.toString()
-    };
+    }
 
     // Combine the metadata and data to create the node
-    const node = Object.assign({}, extraData, nodeMeta);
-    createNode(node);
-  });
+    const node = Object.assign({}, extraData, nodeMeta)
+    createNode(node)
+  })
 
   // Create a node for the most recent LTS release
-  const most_recent_lts = data.most_recent_lts;
-  const nodeContent = JSON.stringify(most_recent_lts);
+  const latestLTS = data.most_recent_lts
+  const nodeContent = JSON.stringify(latestLTS)
   const node = {
-    id: createNodeId(`adoptium-lts-most-recent`), // Unique identifier for each node
-    version: most_recent_lts,
+    id: createNodeId('adoptium-lts-most-recent'), // Unique identifier for each node
+    version: latestLTS,
     parent: null,
     children: [],
     internal: {
@@ -64,9 +64,9 @@ exports.sourceNodes = async ({ actions, createNodeId }) => {
         .update(nodeContent)
         .digest('hex')
     }
-  };
-  createNode(node);
-};
+  }
+  createNode(node)
+}
 
 exports.onCreatePage = ({ page, actions }) => {
   const { createPage, deletePage } = actions

--- a/src/components/DownloadDropdowns/__tests__/__snapshots__/DownloadDropdowns.test.tsx.snap
+++ b/src/components/DownloadDropdowns/__tests__/__snapshots__/DownloadDropdowns.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`DownloadDropdowns component > renders correctly - marketplace 1`] = `
         <option
           value="1"
         >
-          1
+          1 - LTS
         </option>
       </select>
     </div>
@@ -222,7 +222,12 @@ exports[`DownloadDropdowns component > renders correctly 1`] = `
         <option
           value="1"
         >
-          1
+          1 - LTS
+        </option>
+        <option
+          value="2"
+        >
+          2
         </option>
       </select>
     </div>

--- a/src/components/DownloadDropdowns/index.tsx
+++ b/src/components/DownloadDropdowns/index.tsx
@@ -27,7 +27,7 @@ const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
     }
 
     if (marketplace) {
-        versionList = versions;
+        versionList = versionsLTS;
         defaultArch = defaultArchitecture;
         const userOS = detectOS();
         switch (userOS) {

--- a/src/components/DownloadDropdowns/index.tsx
+++ b/src/components/DownloadDropdowns/index.tsx
@@ -16,14 +16,14 @@ const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
     let selectedVersion = defaultVersion;
     const versionParam = queryString.parse(useLocation().search).version;
     if (versionParam) {
-        selectedVersion = Number(versionParam);
+        selectedVersion = Number(versionParam).toString();
     }
     const variantParam = queryString.parse(useLocation().search).variant;
     if (variantParam) {
         // convert openjdk11 to 11
         const parsedVersion = variantParam.toString().replace(/\D/g, '')
         setURLParam('version', parsedVersion)
-        selectedVersion = parseInt(parsedVersion);
+        selectedVersion = parsedVersion;
     }
 
     if (marketplace) {
@@ -62,6 +62,17 @@ const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
     const [checkbox, updateCheckbox] = useState({checkboxRef});
 
     const [releases, setReleases] = useState(null);
+
+    const getVersion = (version) => {
+        let truncatedVersion = version.toString();
+
+        if (truncatedVersion.endsWith(" - LTS")) {
+          truncatedVersion = truncatedVersion.replace(" - LTS", "");
+        }
+        let convertedVersion = parseInt(truncatedVersion);
+
+        return convertedVersion;
+    }
 
     useEffect(() => {
         (async () => {
@@ -132,7 +143,7 @@ const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
                     <select id="version-filter" aria-label="Version Filter" data-testid="version-filter" onChange={(e) => setVersion(e.target.value)} value={version} className="form-select form-select-sm">
                         {versionList.map(
                             (version, i): number | JSX.Element => version && (
-                                <option key={version} value={version}>{version}</option>
+                                <option key={version} value={getVersion(version)}>{version}</option>
                             )
                         )}
                     </select>

--- a/src/components/DownloadDropdowns/index.tsx
+++ b/src/components/DownloadDropdowns/index.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState, useCallback, useEffect } from 'react';
+import { useStaticQuery, graphql } from 'gatsby';
 import { useLocation } from '@reach/router';
 import queryString from 'query-string';
 import { Trans } from 'gatsby-plugin-react-i18next';
@@ -6,12 +7,32 @@ import VendorSelector from '../VendorSelector'
 import { detectOS, UserOS } from '../../util/detectOS';
 import { setURLParam } from '../../util/setURLParam';
 import { capitalize } from '../../util/capitalize';
-import { oses, arches, packageTypes, versions, versionsLTS, defaultVersion, defaultArchitecture, defaultPackageType} from '../../util/defaults';
+import { oses, arches, packageTypes, defaultArchitecture, defaultPackageType} from '../../util/defaults';
 
 let defaultOS = 'any'
 let defaultArch = 'any'
 
 const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
+    const data = useStaticQuery(graphql`
+        query VersionsQuery {
+        allVersions(sort: {version: DESC}) {
+            edges {
+            node {
+                version
+                label
+                lts
+            }
+            }
+        }
+        mostRecentLts {
+            version
+        }
+        }
+    `)
+
+    const defaultVersion = data.mostRecentLts.version;
+    const versions = data.allVersions.edges;
+
     let versionList = versions;
     let selectedVersion = defaultVersion;
     const versionParam = queryString.parse(useLocation().search).version;
@@ -27,7 +48,10 @@ const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
     }
 
     if (marketplace) {
-        versionList = versionsLTS;
+        // filter non LTS versions
+        versionList = versions.filter((version) => {
+            return version.node.lts === true;
+        });
         defaultArch = defaultArchitecture;
         const userOS = detectOS();
         switch (userOS) {
@@ -35,7 +59,9 @@ const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
                 defaultOS = 'mac'
                 if (typeof document !== 'undefined') {
                     let w = document.createElement("canvas").getContext("webgl");
+                    // @ts-ignore
                     let d = w.getExtension('WEBGL_debug_renderer_info');
+                    // @ts-ignore
                     let g = d && w.getParameter(d.UNMASKED_RENDERER_WEBGL) || "";
                     if (g.match(/Apple/) && !g.match(/Apple GPU/)) {
                         defaultArch = 'aarch64'
@@ -62,17 +88,6 @@ const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
     const [checkbox, updateCheckbox] = useState({checkboxRef});
 
     const [releases, setReleases] = useState(null);
-
-    const getVersion = (version) => {
-        let truncatedVersion = version.toString();
-
-        if (truncatedVersion.endsWith(" - LTS")) {
-          truncatedVersion = truncatedVersion.replace(" - LTS", "");
-        }
-        let convertedVersion = parseInt(truncatedVersion);
-
-        return convertedVersion;
-    }
 
     useEffect(() => {
         (async () => {
@@ -143,7 +158,7 @@ const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
                     <select id="version-filter" aria-label="Version Filter" data-testid="version-filter" onChange={(e) => setVersion(e.target.value)} value={version} className="form-select form-select-sm">
                         {versionList.map(
                             (version, i): number | JSX.Element => version && (
-                                <option key={version} value={getVersion(version)}>{version}</option>
+                                <option key={version.node.id} value={version.node.version}>{version.node.label}</option>
                             )
                         )}
                     </select>

--- a/src/components/DownloadDropdowns/index.tsx
+++ b/src/components/DownloadDropdowns/index.tsx
@@ -27,7 +27,7 @@ const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
     }
 
     if (marketplace) {
-        versionList = versionsLTS;
+        versionList = versions;
         defaultArch = defaultArchitecture;
         const userOS = detectOS();
         switch (userOS) {
@@ -56,7 +56,7 @@ const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
     const [arch, updateArch] = useState(defaultArch);
     const [packageType, updatePackageType] = useState(defaultPackageType);
     const [version, udateVersion] = useState(selectedVersion);
-    
+
     // Marketplace vendor selector only
     const checkboxRef = useRef({});
     const [checkbox, updateCheckbox] = useState({checkboxRef});
@@ -80,7 +80,7 @@ const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
     const setPackageType = useCallback((packageType) => {
         updatePackageType(packageType);
     }, []);
-    
+
     const setVersion = useCallback((version) => {
         setURLParam('version', version);
         udateVersion(version);

--- a/src/components/LatestTemurin/index.tsx
+++ b/src/components/LatestTemurin/index.tsx
@@ -1,6 +1,5 @@
 import React, { MutableRefObject, useRef } from 'react';
 import { Link, Trans } from 'gatsby-plugin-react-i18next';
-import { useStaticQuery, graphql } from 'gatsby';
 import { FaArrowCircleRight, FaArchive, FaDownload } from 'react-icons/fa';
 
 import { detectOS, UserOS } from '../../util/detectOS';
@@ -12,15 +11,7 @@ let arch: string = 'x64'
 let isSafari: boolean
 
 const LatestTemurin = (props): JSX.Element => {
-  const data = useStaticQuery(graphql`
-    query VersionsQuery {
-      mostRecentLts {
-        version
-      }
-    }
-  `)
-
-  const defaultVersion = data.mostRecentLts.version;
+  const defaultVersion = props.latestLTS
 
   const userOS = detectOS();
   switch (userOS) {

--- a/src/components/LatestTemurin/index.tsx
+++ b/src/components/LatestTemurin/index.tsx
@@ -1,11 +1,10 @@
 import React, { MutableRefObject, useRef } from 'react';
-import { Link, Trans } from 'gatsby-plugin-react-i18next'
-
+import { Link, Trans } from 'gatsby-plugin-react-i18next';
+import { useStaticQuery, graphql } from 'gatsby';
 import { FaArrowCircleRight, FaArchive, FaDownload } from 'react-icons/fa';
 
 import { detectOS, UserOS } from '../../util/detectOS';
 import { fetchLatestForOS, useOnScreen } from '../../hooks';
-import { defaultVersion } from '../../util/defaults'
 
 let userOSName: string
 let userOSAPIName: string
@@ -13,6 +12,15 @@ let arch: string = 'x64'
 let isSafari: boolean
 
 const LatestTemurin = (props): JSX.Element => {
+  const data = useStaticQuery(graphql`
+    query VersionsQuery {
+      mostRecentLts {
+        version
+      }
+    }
+  `)
+
+  const defaultVersion = data.mostRecentLts.version;
 
   const userOS = detectOS();
   switch (userOS) {
@@ -21,7 +29,9 @@ const LatestTemurin = (props): JSX.Element => {
       userOSAPIName = 'mac'
       if (typeof document !== 'undefined') {
         let w = document.createElement("canvas").getContext("webgl");
+        // @ts-ignore
         let d = w.getExtension('WEBGL_debug_renderer_info');
+        // @ts-ignore
         let g = d && w.getParameter(d.UNMASKED_RENDERER_WEBGL) || "";
         isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
         //Detect if the user is using a Apple GPU (M1)

--- a/src/components/VersionSelector/__tests__/VersionSelector.test.tsx
+++ b/src/components/VersionSelector/__tests__/VersionSelector.test.tsx
@@ -4,8 +4,9 @@ import queryString from 'query-string';
 import { afterEach, vi } from 'vitest';
 import { useI18next } from 'gatsby-plugin-react-i18next'
 import VersionSelector from '../index';
-import { defaultVersion } from '../../../util/defaults';
 import locales from '../../../../locales/i18n';
+
+const defaultVersion = 1;
 
 describe('VersionSelector', () => {
   const updater = vi.fn();
@@ -55,9 +56,9 @@ describe('VersionSelector', () => {
     queryString.parse = vi.fn().mockReturnValue({});
     render(<VersionSelector updater={updater} releaseType={releaseType} Table={Table} />);
     await act(async () => {
-      fireEvent.change(screen.getByTestId('version-filter'), { target: { value: '8' } });
+      fireEvent.change(screen.getByTestId('version-filter'), { target: { value: '2' } });
     });
-    expect(updater).toHaveBeenCalledWith('8', releaseType, 5, expect.any(Date), 0);
+    expect(updater).toHaveBeenCalledWith('2', releaseType, 5, expect.any(Date), 0);
   });
 
   it('updates the number of builds and build date when the inputs change', async () => {
@@ -76,31 +77,31 @@ describe('VersionSelector', () => {
       expect(datepicker.getAttribute('value')).toBe('01/01/2022');
     });
 
-    expect(updater).lastCalledWith('17', 'ea', '10', expect.any(Date), 0);
+    expect(updater).lastCalledWith('1', 'ea', '10', expect.any(Date), 0);
 
     // Add the snapshot test for the final rendered output
     expect(prettyDOM(container)).toMatchSnapshot();
   });
 
   it('renders the component with version query param', async () => {
-    queryString.parse = vi.fn().mockReturnValue({ version: 11 });
+    queryString.parse = vi.fn().mockReturnValue({ version: 2 });
 
     await act(async () => {
       render(<VersionSelector updater={updater} releaseType={releaseType} Table={Table} />);
     });
-    expect(screen.getByTestId('version-filter')).toHaveValue('11');
+    expect(screen.getByTestId('version-filter')).toHaveValue('2');
     expect(screen.queryByLabelText('View')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('nightly builds prior to:')).not.toBeInTheDocument();
     expect(screen.getByText('Table')).toBeInTheDocument();
   });
 
   it('renders the component with variant query param', async () => {
-    queryString.parse = vi.fn().mockReturnValue({ variant: 'openjdk8' });
+    queryString.parse = vi.fn().mockReturnValue({ variant: 'openjdk2' });
 
     await act(async () => {
       render(<VersionSelector updater={updater} releaseType={releaseType} Table={Table} />);
     });
-    expect(screen.getByTestId('version-filter')).toHaveValue('8');
+    expect(screen.getByTestId('version-filter')).toHaveValue('2');
     expect(screen.queryByLabelText('View')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('nightly builds prior to:')).not.toBeInTheDocument();
     expect(screen.getByText('Table')).toBeInTheDocument();

--- a/src/components/VersionSelector/__tests__/__snapshots__/VersionSelector.test.tsx.snap
+++ b/src/components/VersionSelector/__tests__/__snapshots__/VersionSelector.test.tsx.snap
@@ -20,39 +20,14 @@ exports[`VersionSelector > updates the number of builds and build date when the 
       [33mstyle[39m=[32m\\"max-width: 10em;\\"[39m
     [36m>[39m
       [36m<option[39m
-        [33mvalue[39m=[32m\\"20\\"[39m
+        [33mvalue[39m=[32m\\"1\\"[39m
       [36m>[39m
-        [0m20[0m
+        [0m1 - LTS[0m
       [36m</option>[39m
       [36m<option[39m
-        [33mvalue[39m=[32m\\"19\\"[39m
+        [33mvalue[39m=[32m\\"2\\"[39m
       [36m>[39m
-        [0m19[0m
-      [36m</option>[39m
-      [36m<option[39m
-        [33mvalue[39m=[32m\\"18\\"[39m
-      [36m>[39m
-        [0m18[0m
-      [36m</option>[39m
-      [36m<option[39m
-        [33mvalue[39m=[32m\\"17\\"[39m
-      [36m>[39m
-        [0m17[0m
-      [36m</option>[39m
-      [36m<option[39m
-        [33mvalue[39m=[32m\\"16\\"[39m
-      [36m>[39m
-        [0m16[0m
-      [36m</option>[39m
-      [36m<option[39m
-        [33mvalue[39m=[32m\\"11\\"[39m
-      [36m>[39m
-        [0m11[0m
-      [36m</option>[39m
-      [36m<option[39m
-        [33mvalue[39m=[32m\\"8\\"[39m
-      [36m>[39m
-        [0m8[0m
+        [0m2[0m
       [36m</option>[39m
     [36m</select>[39m
   [36m</div>[39m

--- a/src/components/VersionSelector/index.tsx
+++ b/src/components/VersionSelector/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react';
+import { useStaticQuery, graphql } from 'gatsby';
 import { Trans, useI18next } from 'gatsby-plugin-react-i18next'
 import { useLocation } from '@reach/router';
 import queryString from 'query-string';
@@ -6,10 +7,29 @@ import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker';
 
-import { versions, defaultVersion } from '../../util/defaults'
 import { setURLParam } from '../../util/setURLParam';
 
 const VersionSelector = ({updater, releaseType, Table}) => {
+  const data = useStaticQuery(graphql`
+    query VersionsQuery {
+      allVersions(sort: {version: DESC}) {
+        edges {
+          node {
+            version
+            label
+            lts
+          }
+        }
+      }
+      mostRecentLts {
+        version
+      }
+    }
+  `)
+
+  const defaultVersion = data.mostRecentLts.version;
+  const versions = data.allVersions.edges;
+
   const { language } = useI18next();
 
   let locale;
@@ -61,9 +81,10 @@ const VersionSelector = ({updater, releaseType, Table}) => {
       <div className="input-group p-3 d-flex justify-content-center">
         <label className="px-2 fw-bold" htmlFor="version"><Trans>Version</Trans></label>
         <select data-testid="version-filter" aria-label="version-filter" id="version-filter" onChange={(e) => setVersion(e.target.value)} value={version} className="form-select form-select-sm" style={{ maxWidth: '10em' }}>
+            {/* loop through versions array from graphql */}
             {versions.map(
                 (version, i): number | JSX.Element => version && (
-                    <option key={version} value={version}>{version}</option>
+                    <option key={version.node.id} value={version.node.version}>{version.node.label}</option>
                 )
             )}
         </select>

--- a/src/pages/__tests__/__snapshots__/marketplace.test.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/marketplace.test.tsx.snap
@@ -356,19 +356,9 @@ exports[`Marketplace page > renders correctly 1`] = `
           id="version-filter"
         >
           <option
-            value="17"
+            value="1"
           >
-            17
-          </option>
-          <option
-            value="11"
-          >
-            11
-          </option>
-          <option
-            value="8"
-          >
-            8
+            1 - LTS
           </option>
         </select>
       </div>

--- a/src/pages/__tests__/index.test.tsx
+++ b/src/pages/__tests__/index.test.tsx
@@ -4,9 +4,15 @@ import { describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe';
 import Index, { Head } from '../index';
 
+const mockLatestLTS = {
+  mostRecentLts: {
+    version: 1
+  }
+};
+
 describe('Index page', () => {
   it('renders correctly', () => {
-    const { container } = render(<Index />);
+    const { container } = render(<Index data={mockLatestLTS} />);
     // eslint-disable-next-line
     const pageContent = container.querySelector('main');
 
@@ -21,7 +27,7 @@ describe('Index page', () => {
   });
 
   it('has no accessibility violations', async () => {
-    const { container } = render(<Index />);
+    const { container } = render(<Index data={mockLatestLTS} />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,7 +7,8 @@ import Layout from '../components/Layout'
 import Seo from '../components/Seo'
 import LatestTemurin from '../components/LatestTemurin'
 
-const IndexPage = () => {
+const IndexPage = ({data}) => {
+  const latestLTS = data.mostRecentLts.version
   return (
     <Layout>
       <section id='home' className='home' style={{ overflowX: 'hidden' }}>
@@ -29,7 +30,7 @@ const IndexPage = () => {
                     </Trans>
                   </p>
                 </div>
-                <LatestTemurin page='home' />
+                <LatestTemurin latestLTS={latestLTS} page='home' />
               </div>
             </div>
             <div className='col-md-6'>
@@ -79,6 +80,9 @@ export const query = graphql`
           language
         }
       }
+    }
+    mostRecentLts {
+      version
     }
   }
 `

--- a/src/pages/temurin/__tests__/__snapshots__/archive.test.tsx.snap
+++ b/src/pages/temurin/__tests__/__snapshots__/archive.test.tsx.snap
@@ -106,39 +106,14 @@ exports[`Temurin Archive page > renders correctly 1`] = `
         style="max-width: 10em;"
       >
         <option
-          value="20"
+          value="1"
         >
-          20
+          1 - LTS
         </option>
         <option
-          value="19"
+          value="2"
         >
-          19
-        </option>
-        <option
-          value="18"
-        >
-          18
-        </option>
-        <option
-          value="17"
-        >
-          17
-        </option>
-        <option
-          value="16"
-        >
-          16
-        </option>
-        <option
-          value="11"
-        >
-          11
-        </option>
-        <option
-          value="8"
-        >
-          8
+          2
         </option>
       </select>
     </div>

--- a/src/pages/temurin/__tests__/__snapshots__/nightly.test.tsx.snap
+++ b/src/pages/temurin/__tests__/__snapshots__/nightly.test.tsx.snap
@@ -117,39 +117,14 @@ exports[`Temurin Nightly page > renders correctly 1`] = `
         style="max-width: 10em;"
       >
         <option
-          value="20"
+          value="1"
         >
-          20
+          1 - LTS
         </option>
         <option
-          value="19"
+          value="2"
         >
-          19
-        </option>
-        <option
-          value="18"
-        >
-          18
-        </option>
-        <option
-          value="17"
-        >
-          17
-        </option>
-        <option
-          value="16"
-        >
-          16
-        </option>
-        <option
-          value="11"
-        >
-          11
-        </option>
-        <option
-          value="8"
-        >
-          8
+          2
         </option>
       </select>
     </div>

--- a/src/pages/temurin/__tests__/__snapshots__/releases.test.tsx.snap
+++ b/src/pages/temurin/__tests__/__snapshots__/releases.test.tsx.snap
@@ -215,39 +215,14 @@ exports[`Releases page > renders correctly 1`] = `
           id="version-filter"
         >
           <option
-            value="20"
+            value="1"
           >
-            20
+            1 - LTS
           </option>
           <option
-            value="19"
+            value="2"
           >
-            19
-          </option>
-          <option
-            value="18"
-          >
-            18
-          </option>
-          <option
-            value="17"
-          >
-            17
-          </option>
-          <option
-            value="16"
-          >
-            16
-          </option>
-          <option
-            value="11"
-          >
-            11
-          </option>
-          <option
-            value="8"
-          >
-            8
+            2
           </option>
         </select>
       </div>

--- a/src/pages/temurin/__tests__/index.test.tsx
+++ b/src/pages/temurin/__tests__/index.test.tsx
@@ -10,6 +10,12 @@ import Index, { Head } from '../index';
 vi.mock('../../../hooks/useOnScreen');
 vi.mock('../../../hooks/fetchLatestTemurin');
 
+const mockLatestLTS = {
+  mostRecentLts: {
+    version: 1
+  }
+};
+
 describe('Temurin Index page', () => {
   it('renders correctly', () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -18,7 +24,7 @@ describe('Temurin Index page', () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     fetchLatestForOS.mockReturnValue(createRandomLatestForOSData());
-    const { container } = render(<Index />);
+    const { container } = render(<Index data={mockLatestLTS} />);
     // eslint-disable-next-line
     const pageContent = container.querySelector('main');
 
@@ -39,7 +45,7 @@ describe('Temurin Index page', () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     fetchLatestForOS.mockReturnValue(createRandomLatestForOSData());
-    const { container } = render(<Index />);
+    const { container } = render(<Index data={mockLatestLTS} />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/src/pages/temurin/index.tsx
+++ b/src/pages/temurin/index.tsx
@@ -5,35 +5,38 @@ import Layout from '../../components/Layout'
 import Seo from '../../components/Seo'
 import LatestTemurin from '../../components/LatestTemurin'
 
-const TemurinHome = () => (
-  <Layout>
-    <section className='py-5 text-center container'>
-      <div className='row py-lg-5'>
-        <div className='col-lg-10 col-md-8 mx-auto'>
-          <h1 className='fw-light'>Eclipse Temurin&trade;</h1>
-          <div className='row align-items-center pt-3'>
-            <div className='col-6 col-md-4'>
-              <img
-                src='/images/temurin-light.png'
-                width={150}
-                alt='Temurin logo'
-                className='img-fluid'
-              />
+const TemurinHome = ({data}) => {
+  const latestLTS = data.mostRecentLts.version
+  return (
+    <Layout>
+      <section className='py-5 text-center container'>
+        <div className='row py-lg-5'>
+          <div className='col-lg-10 col-md-8 mx-auto'>
+            <h1 className='fw-light'>Eclipse Temurin&trade;</h1>
+            <div className='row align-items-center pt-3'>
+              <div className='col-6 col-md-4'>
+                <img
+                  src='/images/temurin-light.png'
+                  width={150}
+                  alt='Temurin logo'
+                  className='img-fluid'
+                />
+              </div>
+              <div className='col-12 col-sm-6 col-md-8'>
+                <p className='text-start'>
+                  The Eclipse Temurin project provides code and processes that support the building of runtime binaries and associated
+                  technologies that are high performance, enterprise-caliber, cross-platform, open-source licensed, and Java SE TCK-tested
+                  for general use across the Java ecosystem.
+                </p>
+              </div>
+              <LatestTemurin latestLTS={latestLTS} page='temurin' />
             </div>
-            <div className='col-12 col-sm-6 col-md-8'>
-              <p className='text-start'>
-                The Eclipse Temurin project provides code and processes that support the building of runtime binaries and associated
-                technologies that are high performance, enterprise-caliber, cross-platform, open-source licensed, and Java SE TCK-tested
-                for general use across the Java ecosystem.
-              </p>
-            </div>
-            <LatestTemurin page='temurin' />
           </div>
         </div>
-      </div>
-    </section>
-  </Layout>
-)
+      </section>
+    </Layout>
+  )
+}
 
 export default TemurinHome
 
@@ -51,6 +54,9 @@ export const query = graphql`
           language
         }
       }
+    }
+    mostRecentLts {
+      version
     }
   }
 `

--- a/src/util/__tests__/defaults.test.tsx
+++ b/src/util/__tests__/defaults.test.tsx
@@ -1,4 +1,4 @@
-import { arches, defaultArchitecture, defaultPackageType, defaultVersion, oses, packageTypes, versions, versionsLTS } from "../defaults";
+import { arches, defaultArchitecture, defaultPackageType, oses, packageTypes } from "../defaults";
 import { describe, expect, it } from 'vitest'
 
 describe("defaults", () => {
@@ -6,9 +6,6 @@ describe("defaults", () => {
         expect(oses).toBeInstanceOf(Object);
         expect(arches).toBeInstanceOf(Object);
         expect(packageTypes).toBeInstanceOf(Object);
-        expect(versions).toBeInstanceOf(Object);
-        expect(versionsLTS).toBeInstanceOf(Object);
-        expect(typeof defaultVersion).toBe("number");
         expect(typeof defaultPackageType).toBe("string");
         expect(typeof defaultArchitecture).toBe("string");
     });

--- a/src/util/defaults.tsx
+++ b/src/util/defaults.tsx
@@ -7,8 +7,7 @@ export const packageTypes = ['JDK', 'JRE'];
 const apiUrl = 'https://api.adoptium.net/v3/info/available_releases';
 
 let versions = [];
-let versionsLTS = [];
-let defaultVersion = 17;
+let defaultVersion = '17';
 let defaultPackageType = 'jdk';
 let defaultArchitecture = 'x64';
 
@@ -17,15 +16,20 @@ fetch(apiUrl)
   .then(data => {
     const { available_releases, available_lts_releases, most_recent_lts } = data;
 
-    versions = available_releases; // Use available_releases instead of filtering for non-LTS versions
-    versionsLTS = available_lts_releases;
-    defaultVersion = Math.max(...available_lts_releases);
+    versions = available_releases.map(version => {
+      if (available_lts_releases.includes(version)) {
+        return `${version} - LTS`; // Mark LTS versions with '- LTS'
+      } else {
+        return version;
+      }
+    });
+
+    defaultVersion = `${most_recent_lts} - LTS`;
   })
   .catch(error => {
     console.error('Failed to retrieve Java versions from the API:', error);
-    versions = [20, 19, 18, 17, 16, 11, 8];
-    versionsLTS = [17, 11, 8]; // Fallback LTS versions
-    defaultVersion = 17;
+    versions = ['20', '19', '18', '17', '16', '11', '8']; // Use string values
+    defaultVersion = '17 - LTS';
   });
 
-export { versions, versionsLTS, defaultVersion, defaultPackageType, defaultArchitecture };
+export { versions, defaultVersion, defaultPackageType, defaultArchitecture };

--- a/src/util/defaults.tsx
+++ b/src/util/defaults.tsx
@@ -1,12 +1,31 @@
 // This file is used to store defaults which can be accessed by other Javascript/Typescript functions
 
-export const oses = ['Linux', 'alpine-linux', 'Windows', 'mac', 'AIX', 'Solaris']
-export const arches = ['x64', 'x86', 'aarch64', 's390x', 'ppc64le', 'ppc64', 'arm', 'sparcv9']
-export const packageTypes = ['JDK', 'JRE']
-export const versions = [20, 19, 18, 17, 16, 11, 8]
-// LTS versions only are listed here
-export const versionsLTS = [17, 11, 8]
-// The default JDK version to serve up on pages
-export const defaultVersion = 17
-export const defaultPackageType = 'jdk'
-export const defaultArchitecture = 'x64'
+export const oses = ['Linux', 'alpine-linux', 'Windows', 'mac', 'AIX', 'Solaris'];
+export const arches = ['x64', 'x86', 'aarch64', 's390x', 'ppc64le', 'ppc64', 'arm', 'sparcv9'];
+export const packageTypes = ['JDK', 'JRE'];
+
+const apiUrl = 'https://api.adoptium.net/v3/info/available_releases';
+
+let versions = [];
+let versionsLTS = [];
+let defaultVersion = 17;
+let defaultPackageType = 'jdk';
+let defaultArchitecture = 'x64';
+
+fetch(apiUrl)
+  .then(response => response.json())
+  .then(data => {
+    const { available_releases, available_lts_releases, most_recent_lts } = data;
+
+    versions = available_releases; // Use available_releases instead of filtering for non-LTS versions
+    versionsLTS = available_lts_releases;
+    defaultVersion = most_recent_lts;
+  })
+  .catch(error => {
+    console.error('Failed to retrieve Java versions from the API:', error);
+    versions = [20, 19, 18, 17, 16, 11, 8];
+    versionsLTS = [17, 11, 8]; // Fallback LTS versions
+    defaultVersion = 17;
+  });
+
+export { versions, versionsLTS, defaultVersion, defaultPackageType, defaultArchitecture };

--- a/src/util/defaults.tsx
+++ b/src/util/defaults.tsx
@@ -4,32 +4,7 @@ export const oses = ['Linux', 'alpine-linux', 'Windows', 'mac', 'AIX', 'Solaris'
 export const arches = ['x64', 'x86', 'aarch64', 's390x', 'ppc64le', 'ppc64', 'arm', 'sparcv9'];
 export const packageTypes = ['JDK', 'JRE'];
 
-const apiUrl = 'https://api.adoptium.net/v3/info/available_releases';
-
-let versions = [];
-let defaultVersion = '17';
 let defaultPackageType = 'jdk';
 let defaultArchitecture = 'x64';
 
-fetch(apiUrl)
-  .then(response => response.json())
-  .then(data => {
-    const { available_releases, available_lts_releases, most_recent_lts } = data;
-
-    versions = available_releases.map(version => {
-      if (available_lts_releases.includes(version)) {
-        return `${version} - LTS`; // Mark LTS versions with '- LTS'
-      } else {
-        return version;
-      }
-    });
-
-    defaultVersion = `${most_recent_lts} - LTS`;
-  })
-  .catch(error => {
-    console.error('Failed to retrieve Java versions from the API:', error);
-    versions = ['20', '19', '18', '17', '16', '11', '8']; // Use string values
-    defaultVersion = '17 - LTS';
-  });
-
-export { versions, defaultVersion, defaultPackageType, defaultArchitecture };
+export { defaultPackageType, defaultArchitecture };

--- a/src/util/defaults.tsx
+++ b/src/util/defaults.tsx
@@ -19,7 +19,7 @@ fetch(apiUrl)
 
     versions = available_releases; // Use available_releases instead of filtering for non-LTS versions
     versionsLTS = available_lts_releases;
-    defaultVersion = most_recent_lts;
+    defaultVersion = Math.max(...available_lts_releases); // Update defaultVersion to the largest number in available_lts_releases
   })
   .catch(error => {
     console.error('Failed to retrieve Java versions from the API:', error);

--- a/src/util/defaults.tsx
+++ b/src/util/defaults.tsx
@@ -8,8 +8,7 @@ const apiUrl = 'https://api.adoptium.net/v3/info/available_releases';
 
 let versions = [];
 let versionsLTS = [];
-let defaultVersionNumber = 17; // Store default version as a number
-let defaultVersion = `${defaultVersionNumber}`; // Store default version as a string
+let defaultVersion = 17;
 let defaultPackageType = 'jdk';
 let defaultArchitecture = 'x64';
 
@@ -18,24 +17,15 @@ fetch(apiUrl)
   .then(data => {
     const { available_releases, available_lts_releases, most_recent_lts } = data;
 
-    versions = available_releases;
-
-    versionsLTS = available_lts_releases.map(version => `${version} - LTS`);
-
-    defaultVersionNumber = Math.max(...available_lts_releases);
-
-    if (!available_lts_releases.includes(defaultVersionNumber)) {
-      defaultVersion = `${defaultVersionNumber} - LTS`;
-    } else {
-      defaultVersion = `${defaultVersionNumber}`;
-    }
+    versions = available_releases; // Use available_releases instead of filtering for non-LTS versions
+    versionsLTS = available_lts_releases;
+    defaultVersion = Math.max(...available_lts_releases);
   })
   .catch(error => {
     console.error('Failed to retrieve Java versions from the API:', error);
     versions = [20, 19, 18, 17, 16, 11, 8];
     versionsLTS = [17, 11, 8]; // Fallback LTS versions
-    defaultVersionNumber = 17;
-    defaultVersion = `${defaultVersionNumber}`;
+    defaultVersion = 17;
   });
 
 export { versions, versionsLTS, defaultVersion, defaultPackageType, defaultArchitecture };

--- a/src/util/defaults.tsx
+++ b/src/util/defaults.tsx
@@ -8,7 +8,8 @@ const apiUrl = 'https://api.adoptium.net/v3/info/available_releases';
 
 let versions = [];
 let versionsLTS = [];
-let defaultVersion = 17;
+let defaultVersionNumber = 17; // Store default version as a number
+let defaultVersion = `${defaultVersionNumber}`; // Store default version as a string
 let defaultPackageType = 'jdk';
 let defaultArchitecture = 'x64';
 
@@ -17,15 +18,24 @@ fetch(apiUrl)
   .then(data => {
     const { available_releases, available_lts_releases, most_recent_lts } = data;
 
-    versions = available_releases; // Use available_releases instead of filtering for non-LTS versions
-    versionsLTS = available_lts_releases;
-    defaultVersion = Math.max(...available_lts_releases); // Update defaultVersion to the largest number in available_lts_releases
+    versions = available_releases;
+
+    versionsLTS = available_lts_releases.map(version => `${version} - LTS`);
+
+    defaultVersionNumber = Math.max(...available_lts_releases);
+
+    if (!available_lts_releases.includes(defaultVersionNumber)) {
+      defaultVersion = `${defaultVersionNumber} - LTS`;
+    } else {
+      defaultVersion = `${defaultVersionNumber}`;
+    }
   })
   .catch(error => {
     console.error('Failed to retrieve Java versions from the API:', error);
     versions = [20, 19, 18, 17, 16, 11, 8];
     versionsLTS = [17, 11, 8]; // Fallback LTS versions
-    defaultVersion = 17;
+    defaultVersionNumber = 17;
+    defaultVersion = `${defaultVersionNumber}`;
   });
 
 export { versions, versionsLTS, defaultVersion, defaultPackageType, defaultArchitecture };

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -20,6 +20,29 @@ vi.mock('gatsby', async () => {
         siteUrl: 'https://sample.com',
       }
     },
+    mostRecentLts: {
+      version: 1,
+    },
+    allVersions: {
+      edges: [
+        {
+          node: {
+            id: 'mock-id-1',
+            version: 1,
+            label: '1 - LTS',
+            lts: true,
+          }
+        },
+        {
+          node: {
+            id: 'mock-id-2',
+            version: 2,
+            label: '2',
+            lts: false,
+          }
+        },
+      ]
+    },
     avatar: {
       edges: [
         {


### PR DESCRIPTION
# Pick up Java version numbers from API rather than hard coding
<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)

Fixes https://github.com/adoptium/adoptium.net/issues/1622

I have managed to include even non LTS version, i.e 16, 18,19 as input for the dropdown list using the api


<img width="1680" alt="Screenshot 1402-02-27 at 15 15 04" src="https://github.com/adoptium/adoptium.net/assets/58124613/fd83059d-9408-400c-bd2e-b85a9975f9a8">

I was wondering how to make them the non LTS versions available for download easily🤔

<img width="1680" alt="Screenshot 1402-02-27 at 15 42 40" src="https://github.com/adoptium/adoptium.net/assets/58124613/6df6a6d7-3f1c-42f5-b34f-7d25123dfac6">

cc @hendrikebbers @tellison @gdams @zdtsw @smlambert 
