### PR TITLE
Update site title defined in gatsby-config.js

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -249,8 +249,8 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-manifest',
       options: {
-        name: 'gatsby-starter-bootstrap-5',
-        short_name: 'gb5-starter',
+        name: 'eclipse-adoptium',
+        short_name: 'adoptium',
         start_url: '/',
         background_color: '#663399',
         theme_color: '#663399',


### PR DESCRIPTION
# Description of change
Currently when a user "installs" the site as a plugin the name is wrong:

![Screenshot 2023-06-06 at 22 49 20](https://github.com/adoptium/adoptium.net/assets/20224954/5f92128d-8a13-4361-a600-59c21e5f4837)


## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
