### PR TITLE
Preserve filter selections for history.back in releases page

### DIFF
--- a/src/components/ReleaseNotesRender/__tests__/__snapshots__/ReleaseNotesRender.test.tsx.snap
+++ b/src/components/ReleaseNotesRender/__tests__/__snapshots__/ReleaseNotesRender.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`ReleaseNotesRender component > should render correctly 1`] = `
           aria-label="Release Notes"
           aria-multiselectable="false"
           aria-rowcount="3"
-          class="MuiDataGrid-root MuiDataGrid-autoHeight MuiDataGrid-root--densityStandard MuiDataGrid-withBorderColor css-18q4k0e-MuiDataGrid-root"
+          class="MuiDataGrid-root MuiDataGrid-autoHeight MuiDataGrid-root--densityStandard MuiDataGrid-withBorderColor css-yhlmex-MuiDataGrid-root"
           role="grid"
         >
           <div

--- a/src/components/TemurinDownloadTable/__tests__/__snapshots__/TemurinDownloadTable.test.tsx.snap
+++ b/src/components/TemurinDownloadTable/__tests__/__snapshots__/TemurinDownloadTable.test.tsx.snap
@@ -166,10 +166,8 @@ exports[`TemurinDownloadTable component > renders correctly - with source 1`] = 
                 <td
                   class="align-middle"
                 >
-                  <a
+                  <button
                     class="btn btn-primary"
-                    href="/download"
-                    state="[object Object]"
                     style="width: 6em;"
                   >
                     <svg
@@ -187,7 +185,7 @@ exports[`TemurinDownloadTable component > renders correctly - with source 1`] = 
                     </svg>
                      
                     extension_mock
-                  </a>
+                  </button>
                 </td>
               </tr>
             </tbody>
@@ -309,10 +307,8 @@ exports[`TemurinDownloadTable component > renders correctly - with source 1`] = 
                 <td
                   class="align-middle"
                 >
-                  <a
+                  <button
                     class="btn btn-primary"
-                    href="/download"
-                    state="[object Object]"
                     style="width: 6em;"
                   >
                     <svg
@@ -330,7 +326,7 @@ exports[`TemurinDownloadTable component > renders correctly - with source 1`] = 
                     </svg>
                      
                     installer_extension_mock
-                  </a>
+                  </button>
                 </td>
               </tr>
               <tr>
@@ -368,10 +364,8 @@ exports[`TemurinDownloadTable component > renders correctly - with source 1`] = 
                 <td
                   class="align-middle"
                 >
-                  <a
+                  <button
                     class="btn btn-primary"
-                    href="/download"
-                    state="[object Object]"
                     style="width: 6em;"
                   >
                     <svg
@@ -389,7 +383,7 @@ exports[`TemurinDownloadTable component > renders correctly - with source 1`] = 
                     </svg>
                      
                     extension_mock
-                  </a>
+                  </button>
                 </td>
               </tr>
             </tbody>
@@ -535,10 +529,8 @@ exports[`TemurinDownloadTable component > renders correctly 1`] = `
                 <td
                   class="align-middle"
                 >
-                  <a
+                  <button
                     class="btn btn-primary"
-                    href="/download"
-                    state="[object Object]"
                     style="width: 6em;"
                   >
                     <svg
@@ -556,7 +548,7 @@ exports[`TemurinDownloadTable component > renders correctly 1`] = `
                     </svg>
                      
                     extension_mock
-                  </a>
+                  </button>
                 </td>
               </tr>
             </tbody>
@@ -678,10 +670,8 @@ exports[`TemurinDownloadTable component > renders correctly 1`] = `
                 <td
                   class="align-middle"
                 >
-                  <a
+                  <button
                     class="btn btn-primary"
-                    href="/download"
-                    state="[object Object]"
                     style="width: 6em;"
                   >
                     <svg
@@ -699,7 +689,7 @@ exports[`TemurinDownloadTable component > renders correctly 1`] = `
                     </svg>
                      
                     installer_extension_mock
-                  </a>
+                  </button>
                 </td>
               </tr>
               <tr>
@@ -737,10 +727,8 @@ exports[`TemurinDownloadTable component > renders correctly 1`] = `
                 <td
                   class="align-middle"
                 >
-                  <a
+                  <button
                     class="btn btn-primary"
-                    href="/download"
-                    state="[object Object]"
                     style="width: 6em;"
                   >
                     <svg
@@ -758,7 +746,7 @@ exports[`TemurinDownloadTable component > renders correctly 1`] = `
                     </svg>
                      
                     extension_mock
-                  </a>
+                  </button>
                 </td>
               </tr>
             </tbody>

--- a/src/components/TemurinDownloadTable/index.tsx
+++ b/src/components/TemurinDownloadTable/index.tsx
@@ -97,36 +97,48 @@ const TemurinDownloadTable = ({results}) => {
 
 export default TemurinDownloadTable;
 
-const BinaryTable = ({ checksum, link, extension, type, size, os, arch, version }) => {
-    return (
-        <tr>
-            <td className="align-middle text-center">
-                <table><tbody>
-                <tr>
-                    <td>
-                        {`${type} - ${size} MB`}
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <span className="fw-light">
-                            <a href=""
-                                data-bs-toggle="modal"
-                                data-bs-target="#checksumModal"
-                                data-bs-checksum={checksum}>
-                                <small><Trans>Checksum</Trans></small>
-                            </a>
-                        </span>
-                    </td>
-                </tr>
+const BinaryTable = ({ checksum, extension, type, size, os, arch, version }) => {
+    const handleDownloadClick = () => {
+      const link = 'https://adoptium.net/en-GB/download/';
+      window.open(link, "_blank");
+    };
 
-                </tbody></table>
-            </td>
-            <td className="align-middle">
-                <Link to="/download" state={{ link: link, os: os, arch: arch, pkg_type: type, java_version: version }} className="btn btn-primary" style={{width: "6em"}}>
-                    <FaDownload /> {extension}
-                </Link>
-            </td>
-        </tr>
-    )
-}
+    return (
+      <tr>
+        <td className="align-middle text-center">
+          <table>
+            <tbody>
+              <tr>
+                <td>{`${type} - ${size} MB`}</td>
+              </tr>
+              <tr>
+                <td>
+                  <span className="fw-light">
+                    <a
+                      href=""
+                      data-bs-toggle="modal"
+                      data-bs-target="#checksumModal"
+                      data-bs-checksum={checksum}
+                    >
+                      <small>
+                        <Trans>Checksum</Trans>
+                      </small>
+                    </a>
+                  </span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        <td className="align-middle">
+          <button
+            onClick={handleDownloadClick}
+            className="btn btn-primary"
+            style={{ width: "6em" }}
+          >
+            <FaDownload /> {extension}
+          </button>
+        </td>
+      </tr>
+    );
+  };

--- a/src/pages/temurin/__tests__/__snapshots__/release-notes.test.tsx.snap
+++ b/src/pages/temurin/__tests__/__snapshots__/release-notes.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`Temurin Release Notes page > renders correctly 1`] = `
             aria-label="Release Notes"
             aria-multiselectable="false"
             aria-rowcount="2"
-            class="MuiDataGrid-root MuiDataGrid-autoHeight MuiDataGrid-root--densityStandard MuiDataGrid-withBorderColor css-18q4k0e-MuiDataGrid-root"
+            class="MuiDataGrid-root MuiDataGrid-autoHeight MuiDataGrid-root--densityStandard MuiDataGrid-withBorderColor css-yhlmex-MuiDataGrid-root"
             role="grid"
           >
             <div


### PR DESCRIPTION
# Preserve filter selections for history.back in releases page
<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

Fixes https://github.com/adoptium/adoptium.net/issues/859

I considered the download to happen in a new tab

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
