### PR TITLE
Improve visibility of sudo tip to include 'tee' on https://adoptium.net/installation/linux/ for future users

### DIFF
--- a/content/asciidoc-pages/installation/linux/index.adoc
+++ b/content/asciidoc-pages/installation/linux/index.adoc
@@ -13,7 +13,12 @@ See link:/supported-platforms[Supported Platforms] for a list of our officially 
 
 [TIP]
 ====
-On most Linux systems you must have superuser privileges to install packages such as Temurin. You may need to prefix the commands below with `sudo` for them to succeed.
+Please note that on most Linux systems, superuser privileges are required to install packages such as Temurin. To ensure successful execution of the commands below, you may need to prefix them with `sudo`. Additionally, when adding the repository, consider using `sudo tee` to avoid potential permission issues. For example:
+[source, bash]
+----
+echo "deb [arch=amd64] https://some.repository.url focal main" | sudo tee /etc/apt/sources.list.d/adoptium.list > /dev/null
+----
+By using 'sudo tee', you can write the repository entry to the appropriate file with elevated privileges, preventing any write permission errors. This ensures a smooth installation process."
 ====
 
 == Eclipse Temurin Package Names

--- a/content/asciidoc-pages/installation/linux/index.adoc
+++ b/content/asciidoc-pages/installation/linux/index.adoc
@@ -1,5 +1,5 @@
 = Linux (RPM/DEB/APK) installer packages
-:page-authors: gdams, karianna, perlun, TheCrazyLex, TobiX, topaussie, sxa, tellison, luozhenyu
+:page-authors: gdams, karianna, perlun, TheCrazyLex, TobiX, topaussie, sxa, tellison, luozhenyu, Ndacyayisenga-droid
 :toc:
 :icons: font
 
@@ -18,7 +18,7 @@ Please note that on most Linux systems, superuser privileges are required to ins
 ----
 echo "deb [arch=amd64] https://some.repository.url focal main" | sudo tee /etc/apt/sources.list.d/adoptium.list > /dev/null
 ----
-By using 'sudo tee', you can write the repository entry to the appropriate file with elevated privileges, preventing any write permission errors. This ensures a smooth installation process."
+By using `sudo tee`, you can write the repository entry to the appropriate file with elevated privileges, preventing any write permission errors. This ensures a smooth installation process."
 ====
 
 == Eclipse Temurin Package Names


### PR DESCRIPTION
# Improve visibility of sudo tip to include 'tee' on https://adoptium.net/installation/linux/ for future users
<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

Fixes https://github.com/adoptium/adoptium.net/issues/1871

cc @karianna @gdams @hendrikebbers @smlambert 

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
