### PR TITLE
add image popup modal to blog posts to make images clearer

### DIFF
--- a/src/components/GuestPost/__tests__/GuestPost.test.tsx
+++ b/src/components/GuestPost/__tests__/GuestPost.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest'
-import Byline from '../index';
+import GuestPost from '../index';
 
-describe('Byline component', () => {
+describe('GuestPost component', () => {
     it('should render correctly', () => {
         const { container } = render(
-            <Byline
+            <GuestPost
                 children={[]}
             />
         );

--- a/src/components/GuestPost/__tests__/__snapshots__/GuestPost.test.tsx.snap
+++ b/src/components/GuestPost/__tests__/__snapshots__/GuestPost.test.tsx.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Byline component > should render correctly 1`] = `
+exports[`GuestPost component > should render correctly 1`] = `
 <div>
   <p
     style="padding: 0.5em; background-color: rgb(227, 227, 227);"

--- a/src/components/ImagePopup/__tests__/ImagePopup.test.tsx
+++ b/src/components/ImagePopup/__tests__/ImagePopup.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest'
+import ImagePopup from '../index';
+
+describe('ImagePopup component', () => {
+    it('should render correctly', () => {
+        const { container } = render(
+            <ImagePopup
+                alt='test'
+                src='test'
+            />
+        );
+
+        // expect modal to have display: none
+        const modal = container.querySelector('.modal');
+        expect(modal).toHaveStyle('display: none');
+
+        expect(container).toMatchSnapshot();
+    });
+
+    it('should expand image when clicked', () => {
+        const { container } = render(
+            <ImagePopup
+                alt='test'
+                src='test'
+            />
+        );
+
+        // expect modal to have display: none
+        const modal = container.querySelector('.modal');
+        expect(modal).toHaveStyle('display: none');
+
+        const image = container.querySelector('img');
+
+        // open modal
+        if (image) {
+            act(() => {
+                image.click();
+            });
+        }
+        expect(modal).toHaveStyle('display: block');
+
+        // locate modal image
+        const modalImage = container.querySelector('.modal-content img');
+
+        // close modal
+        if (modalImage) {
+            act(() => {
+                // @ts-ignore
+                modalImage.click();
+            });
+        }
+        expect(modal).toHaveStyle('display: none');
+    });
+});

--- a/src/components/ImagePopup/__tests__/__snapshots__/ImagePopup.test.tsx.snap
+++ b/src/components/ImagePopup/__tests__/__snapshots__/ImagePopup.test.tsx.snap
@@ -1,0 +1,36 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ImagePopup component > should render correctly 1`] = `
+<div>
+  <img
+    alt="test"
+    class="img-fluid pb-3"
+    src="test"
+    style="cursor: pointer;"
+  />
+  <div
+    aria-hidden="true"
+    aria-labelledby="exampleModalCenterTitle"
+    class="modal fade "
+    role="dialog"
+    style="display: none;"
+    tabindex="-1"
+  >
+    <div
+      class="modal-dialog modal-dialog-centered"
+      role="document"
+      style="max-width: 90%;"
+    >
+      <div
+        class="modal-content"
+      >
+        <img
+          alt="test"
+          src="test"
+          style="cursor: pointer;"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/ImagePopup/index.tsx
+++ b/src/components/ImagePopup/index.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+
+// create a modal popup for images to be viewed in full screen
+const ImagePopup = (props) => {
+    const [show, setShow] = useState(false);
+    const handleShow = () => setShow(true);
+    const handleClose = () => setShow(false);
+    return (
+      <>
+        <img
+          {...props}
+          className='img-fluid pb-3'
+          style={{ cursor: 'pointer' }}
+          onClick={handleShow}
+          alt={props.alt}
+        />
+        <div
+          className={`modal fade ${show ? 'show' : ''}`}
+          tabIndex={-1}
+          role='dialog'
+          aria-labelledby='exampleModalCenterTitle'
+          aria-hidden='true'
+          style={{ display: show ? 'block' : 'none' }}
+        >
+          <div className='modal-dialog modal-dialog-centered' style={{ maxWidth: '90%' }} role='document'>
+            <div className='modal-content'>
+              <img
+                {...props}
+                style={{ cursor: 'pointer' }}
+                onClick={handleClose}
+                alt={props.alt}
+              />
+            </div>
+          </div>
+        </div>
+      </>
+    );
+};
+
+export default ImagePopup;

--- a/src/templates/blogPost.tsx
+++ b/src/templates/blogPost.tsx
@@ -12,6 +12,7 @@ import Byline from '../components/Byline';
 import ShareButton from '../components/Share';
 import Tags from '../components/Tags';
 import Comments from '../components/Comments';
+import ImagePopup from '../components/ImagePopup';
 
 export const formatDiv = props => {
   // convert inline code to code blocks
@@ -28,6 +29,7 @@ const components = {
   table: props => <table className='table table-hover' {...props} />,
   thead: props => <thead className='table-dark' {...props} />,
   li: props => <li style={{ marginBottom: '1.5em' }} {...props} />,
+  img: props => <ImagePopup {...props} />,
   div: formatDiv
 };
 


### PR DESCRIPTION
# Description of change
See the difference between:

Main: https://adoptium.net/blog/2023/06/adoptium-automated-deployment-of-nagios/

Staging: https://deploy-preview-1947--eclipsefdn-adoptium.netlify.app/blog/2023/06/adoptium-automated-deployment-of-nagios/

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
