### PR TITLE
Temurin Java downloads says x32 instead of x86 but x32 is something else

### DIFF
--- a/src/components/TemurinArchiveTable/index.tsx
+++ b/src/components/TemurinArchiveTable/index.tsx
@@ -66,7 +66,7 @@ const TemurinArchiveTable = ({results, updatePage}) => {
                                                                         <tr key={asset.checksum}>
                                                                             <td>
                                                                             {i === 0 &&
-                                                                                `${capitalize(asset.os)} ${asset.architecture}`
+                                                                                `${capitalize(asset.os)} ${asset.architecture === 'x32' ? 'x86' : asset.architecture}`
                                                                             }
                                                                             </td>
                                                                             <td>

--- a/src/components/TemurinDownloadTable/index.tsx
+++ b/src/components/TemurinDownloadTable/index.tsx
@@ -46,7 +46,7 @@ const TemurinDownloadTable = ({results}) => {
                                     <span className="text-white">{localeDate(pkg.release_date, language)}</span>
                                 </td>
                                 <td className="align-middle w-20">{capitalize(pkg.os)}</td>
-                                <td className="align-middle w-20">{pkg.architecture}</td>
+                                <td className="align-middle w-20">{pkg.architecture === 'x32' ? 'x86' : pkg.architecture}</td>
                                 <td className="align-middle">
                                     <table className="table parent mb-0 w-auto">
                                         {pkg.binaries.map(

--- a/src/components/TemurinNightlyTable/index.tsx
+++ b/src/components/TemurinNightlyTable/index.tsx
@@ -30,7 +30,7 @@ const TemurinNightlyTable = ({results}) => {
                                                 (asset, i): string | JSX.Element =>
                                                     asset && (
                                                         <tr key={`${key}-${asset.type}`} className="nightly-row">
-                                                            <td>{capitalize(asset.os)} {asset.architecture}</td>
+                                                            <td>{capitalize(asset.os)} {asset.architecture === 'x32' ? 'x86' : asset.architecture}</td>
                                                             <td>{asset.type}</td>
                                                             <td>{localeDate(release.timestamp, language)}</td>
                                                             <td><Link to="/download" state={{ link: asset.link, os: capitalize(key.split("-")[0]), arch: key.split("-")[1], pkg_type: asset.type, java_version: 'nightly' }}>{`${asset.extension} (${asset.size} MB)`}</Link></td>


### PR DESCRIPTION
# Changed x32 to match x86
<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

Fixes https://github.com/adoptium/adoptium.net/issues/1948

cc @gdams @hendrikebbers 

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
