### PR TITLE
ARM(32-bit) incorrectly marked as supported on glibc >=2.17, should be >=2.23

### DIFF
--- a/content/asciidoc-pages/supported-platforms/index.adoc
+++ b/content/asciidoc-pages/supported-platforms/index.adoc
@@ -51,7 +51,7 @@ icon:check[] - Supported, icon:docker[] - Docker image available, icon:times[] -
 | Ubuntu 20.04 | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
 | Ubuntu 18.04 | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 
-5+h| Linux (ARM 32-bit Hard-Float) footnote:glibc217[]
+5+h| Linux (ARM 32-bit Hard-Float) footnote:glibc223[These builds should work on any distribution with glibc version 2.23 or higher.]
 | Ubuntu 22.04 | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:times[]
 | Ubuntu 20.04 | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:times[]
 | Ubuntu 18.04 | icon:check[] | icon:check[] | icon:check[] | icon:times[]


### PR DESCRIPTION
# Description of change
<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->
ARM32 distributions are built within a GLIBC 2.23 build environment, so should state supported >= glibc 2.23
Fixes https://github.com/adoptium/adoptium.net-redesign/issues/1161

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
