### PR TITLE
blog: JDK21 early access builds

### DIFF
--- a/content/blog/early-access-builds/index.md
+++ b/content/blog/early-access-builds/index.md
@@ -29,12 +29,14 @@ exactly which tagged level you have discovered any problems with.
 You can download the latest ea build from the API by retrieving this (replace
 linux and x64 with the platform you are interested in:
 
-```
+```text
 https://api.adoptium.net/v3/binary/latest/21/ea/linux/x64/jdk/hotspot/normal/adoptium
 ```
+
 If you want to download a specific EA build instead of the latest, you can
 do so using a URL such as:
-```
+
+```text
 https://api.adoptium.net/v3/binary/version/jdk-21+32-ea-beta/linux/aarch64/jdk/hotspot/normal/adoptium
 ```
 
@@ -42,19 +44,18 @@ The output from java -version for these builds will look like this (but it
 may change in the future) The `-ea` indicates that it is build from the
 early access tag in GitHub:
 
-```
+```output
 openjdk version "21-beta" 2023-09-19
 OpenJDK Runtime Environment Temurin-21+34-202308031254 (build 21-beta+34-ea)
 OpenJDK 64-Bit Server VM Temurin-21+34-202308031254 (build 21-beta+34-ea, mixed mode, sharing)
 ```
-
 
 ## Using the ea builds with GitHub actions
 
 If you want to pull a Temurin JDK21 ea build in a GitHub action, you can use
 the following:
 
-```
+```yaml
      - uses: actions/setup-java@v3
         with:
           java-version: 21-ea

--- a/content/blog/early-access-builds/index.md
+++ b/content/blog/early-access-builds/index.md
@@ -1,6 +1,6 @@
 ---
 title: Early access builds for JDK21
-date: "2023-08-15T16:00:00+00:00"
+date: "2023-08-14T14:00:00+00:00"
 author: sxa
 description: Adoptium are publishing early access "tagged" builds instead of nightlies for JDK21
 tags:
@@ -10,14 +10,15 @@ In addition to the generally available release builds of all currently supported
 versions of openjdk (Currently 8, 11, 17 and 20) Temurin also publishes "nightly"
 development builds of all of those streams as well as the upcoming release (JDK21
 at the moment) as "nightly" or "early access" builds. You can get these from
-https://adoptium.net/temurin/nightly or from the API. Note that while these are
+[the nightly downloads page](https://adoptium.net/temurin/nightly/?version=21)
+or from the API. Note that while these are
 not intended for production use they can be used to test a build containing any
 new fixes which have been put into openjdk along with any new features that
 will be coming in the next release.
 
 ## Early access (ea) tagged builds of JDK21
 
-We have recently changed the way we do the regular nightly builds of JDK21. 
+We have recently changed the way we do the regular nightly builds of JDK21.
 Instead of producing regular builds of the latest development code, we are
 building explicitly from the early access tags when they come out.  This is
 consistent with what OpenJDK does with the builds at
@@ -70,6 +71,3 @@ We are looking at whether it makes sense to build ea levels instead of
 regular nightly head builds of the other supported codebases. If you have a
 view on whether that would be useful please let us know by commenting in
 [this issue](https://github.com/adoptium/temurin-build/issues/3450).
-
-For more information on GPG signing and the impliations of the different steps in the process above, see the
-[integrity checking article from Eclipse](https://wiki.eclipse.org/Platform-releng/How_to_check_integrity_of_downloads#Example_of_using_GPG_with_the_checksums_files).

--- a/content/blog/early-access-builds/index.md
+++ b/content/blog/early-access-builds/index.md
@@ -1,0 +1,71 @@
+---
+title: Early access builds for JDK21
+date: "2023-08-15T16:00:00+00:00"
+author: sxa
+description: Adoptium are publishing early access "tagged" builds instead of nightlies for JDK21
+tags:
+  - temurin
+---
+In addition to the generally available release builds of all currently supported
+versions of openjdk (Currently 8, 11, 17 and 20) Temurin also publishes "nightly"
+development builds of all of those streams as well as the upcoming release (JDK21
+at the moment) as "nightly" or "early access" builds. You can get these from
+https://adoptium.net/temurin/nightly or from the API. Note that while these are
+not inteded for production use they can be used to test a build containing any
+new fixes which have been put into openjdk.
+
+## Early access (ea) builds of JDK21
+
+We have recently changed the way we do the regular builds of JDK21.  Instead
+of producing regular builds of the latest development code, we are building
+the early access tags when they come out.  This is consistent with what
+OpenJDK does with the builds at https://jdk.java.net/21/ but on a wider
+range of platforms.  Similar to the nightly builds mentioned in the
+introduction, these are not for production use but may be useful for testing
+new features as they go into the JDK21 codebase.  By using the specific
+early access tags you can also report issues upstream more easily by knowing
+exactly which tagged level you have discovered any problems with.
+
+You can download the latest ea build from the API by retrieving this (replace
+linux and x64 with the platform you are interested in:
+
+```
+https://api.adoptium.net/v3/binary/latest/21/ea/linux/x64/jdk/hotspot/normal/adoptium
+```
+If you want to download a specific EA build instead of the latest, you can
+do so using a URL such as:
+```
+https://api.adoptium.net/v3/binary/version/jdk-21+32-ea-beta/linux/aarch64/jdk/hotspot/normal/adoptium
+```
+
+The output from java -version for these builds will look like this (but it
+may change in the future) The `-ea` indicates that it is build from the
+early access tag in GitHub:
+
+```
+openjdk version "21-beta" 2023-09-19
+OpenJDK Runtime Environment Temurin-21+34-202308031254 (build 21-beta+34-ea)
+OpenJDK 64-Bit Server VM Temurin-21+34-202308031254 (build 21-beta+34-ea, mixed mode, sharing)
+```
+
+
+## Using the ea builds with GitHub actions
+
+If you want to pull a Temurin JDK21 ea build in a GitHub action, you can use
+the following:
+
+```
+     - uses: actions/setup-java@v3
+        with:
+          java-version: 21-ea
+          distribution: temurin
+```
+
+## Will you be doing this with earlier releases?
+
+We are looking at whether it makes sense to build ea levels instead of
+regular nightly head builds of the other supported codebases. If you have a
+view on whether that would be useful please let us know via slack.
+
+For more information on GPG signing and the impliations of the different steps in the process above, see the
+[integrity checking article from Eclipse](https://wiki.eclipse.org/Platform-releng/How_to_check_integrity_of_downloads#Example_of_using_GPG_with_the_checksums_files)

--- a/content/blog/early-access-builds/index.md
+++ b/content/blog/early-access-builds/index.md
@@ -11,20 +11,22 @@ versions of openjdk (Currently 8, 11, 17 and 20) Temurin also publishes "nightly
 development builds of all of those streams as well as the upcoming release (JDK21
 at the moment) as "nightly" or "early access" builds. You can get these from
 https://adoptium.net/temurin/nightly or from the API. Note that while these are
-not inteded for production use they can be used to test a build containing any
-new fixes which have been put into openjdk.
+not intended for production use they can be used to test a build containing any
+new fixes which have been put into openjdk along with any new features that
+will be coming in the next release.
 
-## Early access (ea) builds of JDK21
+## Early access (ea) tagged builds of JDK21
 
-We have recently changed the way we do the regular builds of JDK21.  Instead
-of producing regular builds of the latest development code, we are building
-the early access tags when they come out.  This is consistent with what
-OpenJDK does with the builds at https://jdk.java.net/21/ but on a wider
-range of platforms.  Similar to the nightly builds mentioned in the
-introduction, these are not for production use but may be useful for testing
-new features as they go into the JDK21 codebase.  By using the specific
-early access tags you can also report issues upstream more easily by knowing
-exactly which tagged level you have discovered any problems with.
+We have recently changed the way we do the regular nightly builds of JDK21. 
+Instead of producing regular builds of the latest development code, we are
+building explicitly from the early access tags when they come out.  This is
+consistent with what OpenJDK does with the builds at
+https://jdk.java.net/21/ but on a wider range of platforms.  Similar to the
+nightly builds mentioned in the introduction, these are not for production
+use but may be useful for testing new features as they go into the JDK21
+codebase.  By using the specific early access tags you can also report
+issues upstream more easily by knowing exactly which tagged level you have
+discovered any problems with.
 
 You can download the latest ea build from the API by retrieving this (replace
 linux and x64 with the platform you are interested in:
@@ -66,7 +68,8 @@ the following:
 
 We are looking at whether it makes sense to build ea levels instead of
 regular nightly head builds of the other supported codebases. If you have a
-view on whether that would be useful please let us know via slack.
+view on whether that would be useful please let us know by commenting in
+[this issue](https://github.com/adoptium/temurin-build/issues/3450).
 
 For more information on GPG signing and the impliations of the different steps in the process above, see the
 [integrity checking article from Eclipse](https://wiki.eclipse.org/Platform-releng/How_to_check_integrity_of_downloads#Example_of_using_GPG_with_the_checksums_files).

--- a/content/blog/early-access-builds/index.md
+++ b/content/blog/early-access-builds/index.md
@@ -69,4 +69,4 @@ regular nightly head builds of the other supported codebases. If you have a
 view on whether that would be useful please let us know via slack.
 
 For more information on GPG signing and the impliations of the different steps in the process above, see the
-[integrity checking article from Eclipse](https://wiki.eclipse.org/Platform-releng/How_to_check_integrity_of_downloads#Example_of_using_GPG_with_the_checksums_files)
+[integrity checking article from Eclipse](https://wiki.eclipse.org/Platform-releng/How_to_check_integrity_of_downloads#Example_of_using_GPG_with_the_checksums_files).


### PR DESCRIPTION
Blog post to tell people that we are providing early access builds  of JDK21 from the tagged levels in the repository. Some further redrafting will likely occur and I want to try and ensure that we get the uilds also available through the website before publishing, assuming the sorting works correctly.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

Sine this is just a new blog file, I have not ticked any of the boxes below, and AIUI `npm test` is a bit broken just now anyway.

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
