### PR TITLE
Fix/adoptium 555 fix homepage cls problem

### DIFF
--- a/src/components/LatestTemurin/index.tsx
+++ b/src/components/LatestTemurin/index.tsx
@@ -83,15 +83,15 @@ const LatestTemurin = (props): JSX.Element => {
                     <br/>
                     <span style={{ fontSize: '.6em'}} className="font-weight-light">{binary.release_name}</span>
                 </Link>
-                <Link to="/temurin/releases" className="btn btn-outline-dark mt-3">
-                    <Trans>Other platforms and versions</Trans> <FaArrowCircleRight />
-                </Link>
               </>
             ) :
               <Link to="/temurin/releases" className="btn btn-lg btn-primary mt-3 py-3 text-white">
                   <FaDownload /> Latest LTS releases
               </Link>
             }
+            <Link to="/temurin/releases" className="btn btn-outline-dark mt-3">
+                <Trans>Other platforms and versions</Trans> <FaArrowCircleRight />
+            </Link>
             <Link to="/temurin/archive" className="btn btn-outline-dark mt-3">
                 <Trans>Release Archive</Trans> <FaArchive />
             </Link>

--- a/src/pages/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/index.test.tsx.snap
@@ -72,6 +72,26 @@ exports[`Index page > renders correctly 1`] = `
                 </a>
                 <a
                   class="btn btn-outline-dark mt-3"
+                  href="/temurin/releases"
+                >
+                  Text
+                   
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M256 8c137 0 248 111 248 248S393 504 256 504 8 393 8 256 119 8 256 8zm-28.9 143.6l75.5 72.4H120c-13.3 0-24 10.7-24 24v16c0 13.3 10.7 24 24 24h182.6l-75.5 72.4c-9.7 9.3-9.9 24.8-.4 34.3l11 10.9c9.4 9.4 24.6 9.4 33.9 0L404.3 273c9.4-9.4 9.4-24.6 0-33.9L271.6 106.3c-9.4-9.4-24.6-9.4-33.9 0l-11 10.9c-9.5 9.6-9.3 25.1.4 34.4z"
+                    />
+                  </svg>
+                </a>
+                <a
+                  class="btn btn-outline-dark mt-3"
                   href="/temurin/archive"
                 >
                   Text


### PR DESCRIPTION
# Description of change

The button to  "/temurin/releases" is now always visible like the archive one, and not conditionned by the end of the call to fetchLatestForOS().

## Checklist

- [x] `npm test` passes
