### PR TITLE
Clarify requirements for AIX runtimes

### DIFF
--- a/content/asciidoc-pages/supported-platforms/index.adoc
+++ b/content/asciidoc-pages/supported-platforms/index.adoc
@@ -65,7 +65,7 @@ icon:check[] - Supported, icon:docker[] - Docker image available, icon:times[] -
 | Ubuntu 18.04 | icon:check[] | icon:check[] | icon:check[] | icon:times[]
 
 5+h| Linux (s390x) footnote:glibc217[]
-| RHEL / UBI 9.x | icon:times[] footnote:nojit[JDK8 on s390 has no JIT so is unsupported.] | icon:check[] | icon:check[] | icon:times[]
+| RHEL / UBI 9.x | icon:times[] footnote:nojit[JDK8 on s390x has no JIT so is unsupported.] | icon:check[] | icon:check[] | icon:times[]
 | RHEL / UBI 8.x | icon:times[] footnote:nojit[] | icon:check[] | icon:check[] | icon:times[]
 | RHEL 7.x | icon:times[] footnote:nojit[] | icon:check[] | icon:check[] | icon:times[]
 | Ubuntu 22.04 | icon:times[] footnote:nojit[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:times[]
@@ -87,10 +87,8 @@ icon:check[] - Supported, icon:docker[] - Docker image available, icon:times[] -
 | Solaris 11 | icon:check[] | icon:times[] | icon:times[] | icon:times[]
 | Solaris 10u11 | icon:check[] | icon:times[] | icon:times[] | icon:times[]
 
-5+h| AIX (PowerPC 64-bit Big Endian)
+5+h| AIX (PowerPC 64-bit Big Endian) footnote:aix71[Running the latest versions on AIX 7.1 is no longer supported. The last versions which targetted able to run on AIX 7.1 were jdk8u362, jdk-11.0.18 and jdk-17.0.8] footnote:alxrt[Requires XLC runtime packages from the compiler or standalone for XLC 13 for JDK8: https://www.ibm.com/support/pages/ibm-xl-cc-runtime-aix-131 or XLC 16 for JDK11+: https://www.ibm.com/support/pages/ibm-xl-cc-runtime-aix-161]
 | AIX 7.2 | icon:check[] | icon:check[] | icon:check[] | icon:times[]
-| AIX 7.1 TL5 SP5 | icon:check[] | icon:check[] | icon:check[] | icon:times[]
-| AIX 7.1 TL4 | icon:check[] | icon:check[]| icon:check[] | icon:times[]
 |===
 --
 


### PR DESCRIPTION
Remove AIX 7.1 with a note referencing the last versions that worked on that level.
Provide links to the AIX XLC runtime downloads which are prerequisites for running Temurin on AIX.
This infromation was spotted as missing from [this slack conversation](https://adoptium.slack.com/archives/C09NLQQAV/p1691760141575469)

<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
