### PR TITLE
Add buttons in Releases page to go to Archive AND Nightly Builds

### DIFF
--- a/src/pages/temurin/__tests__/__snapshots__/releases.test.tsx.snap
+++ b/src/pages/temurin/__tests__/__snapshots__/releases.test.tsx.snap
@@ -334,11 +334,31 @@ exports[`Releases page > renders correctly 1`] = `
         Text
       </p>
       <div
-        class="btn-group-vertical col-6 mx-auto"
+        class="btn-group"
       >
         <a
-          class="btn btn btn-primary mt-3"
+          class="btn btn-primary m-3"
           href="/temurin/archive"
+        >
+          Text
+           
+          <svg
+            fill="currentColor"
+            height="1em"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 512 512"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M256 8c137 0 248 111 248 248S393 504 256 504 8 393 8 256 119 8 256 8zm-28.9 143.6l75.5 72.4H120c-13.3 0-24 10.7-24 24v16c0 13.3 10.7 24 24 24h182.6l-75.5 72.4c-9.7 9.3-9.9 24.8-.4 34.3l11 10.9c9.4 9.4 24.6 9.4 33.9 0L404.3 273c9.4-9.4 9.4-24.6 0-33.9L271.6 106.3c-9.4-9.4-24.6-9.4-33.9 0l-11 10.9c-9.5 9.6-9.3 25.1.4 34.4z"
+            />
+          </svg>
+        </a>
+        <a
+          class="btn btn-secondary m-3"
+          href="/temurin/nightly"
         >
           Text
            

--- a/src/pages/temurin/releases.tsx
+++ b/src/pages/temurin/releases.tsx
@@ -53,9 +53,12 @@ const TemurinReleases = () => (
         <p className='text-center'>
           <Trans>Previous releases are available in the Temurin archive.</Trans>
         </p>
-        <div className='btn-group-vertical col-6 mx-auto'>
-          <Link to='/temurin/archive' className='btn btn btn-primary mt-3'>
+        <div className='btn-group'>
+          <Link to='/temurin/archive' className='btn btn-primary m-3'>
             <Trans>Release Archive</Trans> <FaArrowCircleRight />
+          </Link>
+          <Link to='/temurin/nightly' className='btn btn-secondary m-3'>
+            <Trans>Nightly Builds</Trans> <FaArrowCircleRight />
           </Link>
         </div>
       </div>


### PR DESCRIPTION
# Description of change
As well as in *Archive* page and *Nightly Builds* page, I suggest to add both buttons in the bottom of the *Latest Releases* page, by adding the link to Nightly Builds.

- add button to Nightly Builds
- fix css (btn btn)

## Checklist

- [x] `npm test` passes

![image](https://github.com/adoptium/adoptium.net/assets/3774556/642d6c59-081f-4325-9216-b7569343639a)

