### PR TITLE
Fix/adoptium 666 bookmark support

### DIFF
--- a/src/components/DownloadDropdowns/__tests__/DownloadDropdowns.test.tsx
+++ b/src/components/DownloadDropdowns/__tests__/DownloadDropdowns.test.tsx
@@ -26,7 +26,7 @@ vi.mock('../../../util/defaults', () => {
     versionsLTS: [1],
     defaultPackageType: 'jdk',
     defaultArchitecture: 'mock_arch',
-    packageTypes: ['jdk'],
+    packageTypes: ['mock_jdk'],
   }
 });
 
@@ -85,7 +85,7 @@ describe('DownloadDropdowns component', () => {
 
     select = getByTestId('package-type-filter');
     await act(async () => {
-      fireEvent.change(select, { target: { value: 'any' } });
+      fireEvent.change(select, { target: { value: 'mock_jdk' } });
     });
 
     expect(updater).toHaveBeenCalledTimes(4);

--- a/src/components/DownloadDropdowns/__tests__/DownloadDropdowns.test.tsx
+++ b/src/components/DownloadDropdowns/__tests__/DownloadDropdowns.test.tsx
@@ -46,8 +46,11 @@ const updater = vi.fn().mockImplementation(() => {
 vi.mock('query-string', () => ({
   default: {
     parse: () => ({
-      version: 8,
-      variant: 'openjdk8',
+      os: 'linux',
+      arch: 'x64',
+      package: 'jdk',
+      version: 17,
+      variant: 'openjdk11',
     }),
   }
 }));

--- a/src/components/DownloadDropdowns/__tests__/__snapshots__/DownloadDropdowns.test.tsx.snap
+++ b/src/components/DownloadDropdowns/__tests__/__snapshots__/DownloadDropdowns.test.tsx.snap
@@ -83,9 +83,9 @@ exports[`DownloadDropdowns component > renders correctly - marketplace 1`] = `
           Any
         </option>
         <option
-          value="jdk"
+          value="mock_jdk"
         >
-          jdk
+          mock_jdk
         </option>
       </select>
     </div>
@@ -198,9 +198,9 @@ exports[`DownloadDropdowns component > renders correctly 1`] = `
           Any
         </option>
         <option
-          value="jdk"
+          value="mock_jdk"
         >
-          jdk
+          mock_jdk
         </option>
       </select>
     </div>

--- a/src/components/DownloadDropdowns/index.tsx
+++ b/src/components/DownloadDropdowns/index.tsx
@@ -9,10 +9,8 @@ import { setURLParam } from '../../util/setURLParam';
 import { capitalize } from '../../util/capitalize';
 import { oses, arches, packageTypes, defaultArchitecture, defaultPackageType} from '../../util/defaults';
 
-let defaultOS = 'any'
-let defaultArch = 'any'
-
 const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
+
     const data = useStaticQuery(graphql`
       query VersionsQuery {
         allVersions(sort: {version: DESC}) {
@@ -33,33 +31,51 @@ const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
       }
     `)
 
-    const defaultVersion = data.mostRecentLts.version;
-    const versions = data.allVersions.edges;
+    let defaultSelectedOS = 'any';
+    const osParam = queryString.parse(useLocation().search).os;
+    if (osParam) {
+        defaultSelectedOS = osParam.toString();
+    }
 
-    let versionList = versions;
-    let selectedVersion = defaultVersion;
+    let defaultSelectedArch = 'any';
+    const archParam = queryString.parse(useLocation().search).arch;
+    if (archParam) {
+        defaultSelectedArch = archParam.toString();
+    }
+
+    let defaultSelectedPackageType = 'any';
+    const packageTypeParam = queryString.parse(useLocation().search).packageType;
+    if (packageTypeParam) {
+        defaultSelectedPackageType = packageTypeParam.toString();
+    }
+
+    let defaultSelectedVersion = data.mostRecentLts.version;
     const versionParam = queryString.parse(useLocation().search).version;
     if (versionParam) {
-        selectedVersion = Number(versionParam).toString();
+        defaultSelectedVersion = Number(versionParam).toString();
     }
     const variantParam = queryString.parse(useLocation().search).variant;
     if (variantParam) {
         // convert openjdk11 to 11
         const parsedVersion = variantParam.toString().replace(/\D/g, '')
-        setURLParam('version', parsedVersion)
-        selectedVersion = parsedVersion;
+        defaultSelectedVersion = parsedVersion;
     }
+
+    // prepare versions list
+    const versions = data.allVersions.edges;
+    let versionList = versions;
 
     if (marketplace) {
         // filter non LTS versions
         versionList = versions.filter((version) => {
             return version.node.lts === true;
         });
-        defaultArch = defaultArchitecture;
+        defaultSelectedArch = defaultArchitecture;
+        defaultSelectedPackageType = defaultPackageType;
         const userOS = detectOS();
         switch (userOS) {
             case UserOS.MAC:
-                defaultOS = 'mac'
+                defaultSelectedOS = 'mac'
                 if (typeof document !== 'undefined') {
                     let w = document.createElement("canvas").getContext("webgl");
                     // @ts-ignore
@@ -67,24 +83,24 @@ const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
                     // @ts-ignore
                     let g = d && w.getParameter(d.UNMASKED_RENDERER_WEBGL) || "";
                     if (g.match(/Apple/) && !g.match(/Apple GPU/)) {
-                        defaultArch = 'aarch64'
+                        defaultSelectedArch = 'aarch64'
                     }
                 }
                 break;
             case UserOS.LINUX:
             case UserOS.UNIX:
-                defaultOS = 'linux'
+                defaultSelectedOS = 'linux'
             break;
         default:
-            defaultOS = 'windows'
+            defaultSelectedOS = 'windows'
             break;
         }
     }
 
-    const [os, updateOS] = useState(defaultOS);
-    const [arch, updateArch] = useState(defaultArch);
-    const [packageType, updatePackageType] = useState(defaultPackageType);
-    const [version, udateVersion] = useState(selectedVersion);
+    const [os, updateOS] = useState(defaultSelectedOS);
+    const [arch, updateArch] = useState(defaultSelectedArch);
+    const [packageType, updatePackageType] = useState(defaultSelectedPackageType);
+    const [version, udateVersion] = useState(defaultSelectedVersion);
 
     // Marketplace vendor selector only
     const checkboxRef = useRef({});
@@ -99,14 +115,17 @@ const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
     }, [version, os, arch, packageType, checkbox]);
 
     const setOS = useCallback((os) => {
+        setURLParam('os', os)
         updateOS(os);
     }, []);
 
     const setArch = useCallback((arch) => {
+        setURLParam('arch', arch)
         updateArch(arch);
     }, []);
 
     const setPackageType = useCallback((packageType) => {
+        setURLParam('packageType', packageType)
         updatePackageType(packageType);
     }, []);
 
@@ -127,7 +146,7 @@ const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
                     <label className="px-2 fw-bold" htmlFor="os"><Trans>Operating System</Trans></label>
                     <select id="os-filter" aria-label="OS Filter" data-testid="os-filter" onChange={(e) => setOS(e.target.value)} value={os} className="form-select form-select-sm">
                         <option key="any" value="any">Any</option>
-                        {oses.map(
+                        {oses.sort((os1, os2) => os1.localeCompare(os2)).map(
                             (os, i): string | JSX.Element => os && (
                                 <option key={os.toLowerCase()} value={os.toLowerCase()}>{capitalize(os)}</option>
                             )
@@ -138,7 +157,7 @@ const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
                     <label className="px-2 fw-bold" htmlFor="arch"><Trans>Architecture</Trans></label>
                     <select id="arch-filter" aria-label="Architecture Filter" data-testid="arch-filter" onChange={(e) => setArch(e.target.value)} value={arch} className="form-select form-select-sm">
                         <option key="any" value="any">Any</option>
-                        {arches.map(
+                        {arches.sort((arch1, arch2) => arch1.localeCompare(arch2)).map(
                             (arch, i): string | JSX.Element => arch && (
                                 <option key={arch.toLowerCase()} value={arch.toLowerCase()}>{arch}</option>
                             )

--- a/src/components/DownloadDropdowns/index.tsx
+++ b/src/components/DownloadDropdowns/index.tsx
@@ -31,24 +31,28 @@ const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
       }
     `)
 
+    // init the default selected Operation System, if any from the param 'os'
     let defaultSelectedOS = 'any';
     const osParam = queryString.parse(useLocation().search).os;
     if (osParam) {
         defaultSelectedOS = osParam.toString();
     }
 
+    // init the default selected Architecture, if any from the param 'arch'
     let defaultSelectedArch = 'any';
     const archParam = queryString.parse(useLocation().search).arch;
     if (archParam) {
         defaultSelectedArch = archParam.toString();
     }
 
+    // init the default selected Package Type, if any from the param 'package'
     let defaultSelectedPackageType = 'any';
-    const packageTypeParam = queryString.parse(useLocation().search).packageType;
-    if (packageTypeParam) {
-        defaultSelectedPackageType = packageTypeParam.toString();
+    const packageParam = queryString.parse(useLocation().search).package;
+    if (packageParam) {
+        defaultSelectedPackageType = packageParam.toString();
     }
 
+    // init the default selected Version, if any from the param 'version' or from 'variant'
     let defaultSelectedVersion = data.mostRecentLts.version;
     const versionParam = queryString.parse(useLocation().search).version;
     if (versionParam) {
@@ -125,7 +129,7 @@ const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
     }, []);
 
     const setPackageType = useCallback((packageType) => {
-        setURLParam('packageType', packageType)
+        setURLParam('package', packageType)
         updatePackageType(packageType);
     }, []);
 

--- a/src/components/TemurinDownloadTable/index.tsx
+++ b/src/components/TemurinDownloadTable/index.tsx
@@ -21,7 +21,7 @@ const TemurinDownloadTable = ({results}) => {
         <table id="download-table" className="table table-bordered releases-table" style={{borderSpacing: '0 10px', borderCollapse: 'separate'}}>
             <tbody className="table-light">
             {results ? (
-                results.map(
+                results.sort((pkg1, pkg2) => pkg2.release_date - pkg1.release_date).map(
                     (pkg, i): string | JSX.Element =>
                         pkg && (
                             <tr key={i}>

--- a/src/pages/__tests__/__snapshots__/marketplace.test.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/marketplace.test.tsx.snap
@@ -215,9 +215,9 @@ exports[`Marketplace page > renders correctly 1`] = `
             Any
           </option>
           <option
-            value="linux"
+            value="aix"
           >
-            Linux
+            AIX
           </option>
           <option
             value="alpine-linux"
@@ -225,9 +225,9 @@ exports[`Marketplace page > renders correctly 1`] = `
             Alpine Linux
           </option>
           <option
-            value="windows"
+            value="linux"
           >
-            Windows
+            Linux
           </option>
           <option
             value="mac"
@@ -235,14 +235,14 @@ exports[`Marketplace page > renders correctly 1`] = `
             macOS
           </option>
           <option
-            value="aix"
-          >
-            AIX
-          </option>
-          <option
             value="solaris"
           >
             Solaris
+          </option>
+          <option
+            value="windows"
+          >
+            Windows
           </option>
         </select>
       </div>
@@ -267,6 +267,36 @@ exports[`Marketplace page > renders correctly 1`] = `
             Any
           </option>
           <option
+            value="aarch64"
+          >
+            aarch64
+          </option>
+          <option
+            value="arm"
+          >
+            arm
+          </option>
+          <option
+            value="ppc64"
+          >
+            ppc64
+          </option>
+          <option
+            value="ppc64le"
+          >
+            ppc64le
+          </option>
+          <option
+            value="s390x"
+          >
+            s390x
+          </option>
+          <option
+            value="sparcv9"
+          >
+            sparcv9
+          </option>
+          <option
             value="x64"
           >
             x64
@@ -275,36 +305,6 @@ exports[`Marketplace page > renders correctly 1`] = `
             value="x86"
           >
             x86
-          </option>
-          <option
-            value="aarch64"
-          >
-            aarch64
-          </option>
-          <option
-            value="s390x"
-          >
-            s390x
-          </option>
-          <option
-            value="ppc64le"
-          >
-            ppc64le
-          </option>
-          <option
-            value="ppc64"
-          >
-            ppc64
-          </option>
-          <option
-            value="arm"
-          >
-            arm
-          </option>
-          <option
-            value="sparcv9"
-          >
-            sparcv9
           </option>
         </select>
       </div>

--- a/src/pages/temurin/__tests__/__snapshots__/releases.test.tsx.snap
+++ b/src/pages/temurin/__tests__/__snapshots__/releases.test.tsx.snap
@@ -74,9 +74,9 @@ exports[`Releases page > renders correctly 1`] = `
             Any
           </option>
           <option
-            value="linux"
+            value="aix"
           >
-            Linux
+            AIX
           </option>
           <option
             value="alpine-linux"
@@ -84,9 +84,9 @@ exports[`Releases page > renders correctly 1`] = `
             Alpine Linux
           </option>
           <option
-            value="windows"
+            value="linux"
           >
-            Windows
+            Linux
           </option>
           <option
             value="mac"
@@ -94,14 +94,14 @@ exports[`Releases page > renders correctly 1`] = `
             macOS
           </option>
           <option
-            value="aix"
-          >
-            AIX
-          </option>
-          <option
             value="solaris"
           >
             Solaris
+          </option>
+          <option
+            value="windows"
+          >
+            Windows
           </option>
         </select>
       </div>
@@ -126,6 +126,36 @@ exports[`Releases page > renders correctly 1`] = `
             Any
           </option>
           <option
+            value="aarch64"
+          >
+            aarch64
+          </option>
+          <option
+            value="arm"
+          >
+            arm
+          </option>
+          <option
+            value="ppc64"
+          >
+            ppc64
+          </option>
+          <option
+            value="ppc64le"
+          >
+            ppc64le
+          </option>
+          <option
+            value="s390x"
+          >
+            s390x
+          </option>
+          <option
+            value="sparcv9"
+          >
+            sparcv9
+          </option>
+          <option
             value="x64"
           >
             x64
@@ -134,36 +164,6 @@ exports[`Releases page > renders correctly 1`] = `
             value="x86"
           >
             x86
-          </option>
-          <option
-            value="aarch64"
-          >
-            aarch64
-          </option>
-          <option
-            value="s390x"
-          >
-            s390x
-          </option>
-          <option
-            value="ppc64le"
-          >
-            ppc64le
-          </option>
-          <option
-            value="ppc64"
-          >
-            ppc64
-          </option>
-          <option
-            value="arm"
-          >
-            arm
-          </option>
-          <option
-            value="sparcv9"
-          >
-            sparcv9
           </option>
         </select>
       </div>

--- a/src/util/setURLParam.tsx
+++ b/src/util/setURLParam.tsx
@@ -1,4 +1,27 @@
 export function setURLParam (param: any, value: any) {
-    let currentURL = window.location.protocol + "//" + window.location.host + window.location.pathname + `?${param}=${value}`;    
+    let currentURLWithParams = window.location.href;
+
+    let params = {};
+
+    // parse existing query parameters (if any)
+    if(currentURLWithParams.indexOf('?') > 0) {
+        currentURLWithParams.substring(currentURLWithParams.indexOf('?')+1)
+            .split('&')
+            .forEach(item => {
+                params[item.split('=')[0]]=item.split('=')[1];
+            });
+    }
+    if(param) {
+        // set the new value for the given param or unset if no value provided
+        if(value === undefined) delete params[param];
+        else params[param]=value;
+    }
+
+    // rebuild and set the location
+    var queryString = Object.keys(params).map((key) => {
+        return encodeURIComponent(key) + '=' + encodeURIComponent(params[key])
+    }).join('&');
+
+    let currentURL = window.location.protocol + "//" + window.location.host + window.location.pathname + `?${queryString}`;
     window.history.replaceState({ path: currentURL }, '', currentURL);
 }


### PR DESCRIPTION
# Description of change
Fix issue #666  "Bookmark Support"

When going to https://adoptium.net/temurin/releases/ 

- It's now possible to select values from dropdowns and they are added to the URL. 
- A bookmarked link is now supported and all filters are applied to the query.
- Results are ordered from newest to oldest (release_date DESC).
- Dropdowns are sorted alphabetically (more intuitive).

**Supported parameters are**:
- os=[windows, linux...]  default 'any'
- arch=[x64, x86...]  default 'any'
- package=[jdk, jre] default 'any' or 'jdk' in marketplace
- version=[19, 18...] default is 'lastest'
- variant=[openjdk11,...]

Function setURLParam() has been improved with:
- it add a new parameter without loosing existing ones (append mode)
- ability to "remove" a parameter by passing 'undefined' as value

e.g. http://localhost:8000/temurin/releases/?os=linux&arch=x64&package=jdk

## Checklist

- [x] `npm test` passes
