### PR TITLE
[adoptium-1564] Add support for latest version

### DIFF
--- a/src/components/DownloadDropdowns/__tests__/DownloadDropdowns.test.tsx
+++ b/src/components/DownloadDropdowns/__tests__/DownloadDropdowns.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { act } from 'react-test-renderer';
 import { createRandomTemurinReleases } from '../../../__fixtures__/hooks';
 import DownloadDropdowns from '..';
+import queryString from 'query-string';
 
 const Table = () => {
   return (
@@ -21,12 +22,9 @@ vi.mock('../../../util/defaults', () => {
   return {
     oses: ['mock_os'],
     arches: ['mock_arch'],
-    versions: [1],
-    defaultVersion: 1,
-    versionsLTS: [1],
-    defaultPackageType: 'jdk',
+    packageTypes: ['mock_pkg'],
+    defaultPackageType: 'mock_pkg',
     defaultArchitecture: 'mock_arch',
-    packageTypes: ['mock_jdk'],
   }
 });
 
@@ -49,7 +47,7 @@ vi.mock('query-string', () => ({
       os: 'linux',
       arch: 'x64',
       package: 'jdk',
-      version: 17,
+      version: 'latest',
       variant: 'openjdk11',
     }),
   }
@@ -88,18 +86,102 @@ describe('DownloadDropdowns component', () => {
 
     select = getByTestId('package-type-filter');
     await act(async () => {
-      fireEvent.change(select, { target: { value: 'mock_jdk' } });
+      fireEvent.change(select, { target: { value: 'mock_pkg' } });
     });
 
     expect(updater).toHaveBeenCalledTimes(4);
 
     select = getByTestId('version-filter');
     await act(async () => {
-      fireEvent.change(select, { target: { value: 1 } });
+      fireEvent.change(select, { target: { value: 2 } });
     });
 
     expect(updater).toHaveBeenCalledTimes(5);
     expect(container).toMatchSnapshot();
+  });
+
+  it('renders correctly - use URL param os=mock_os', async () => {
+    queryString.parse = vi.fn().mockReturnValue({'os': "mock_os"});
+
+    const { container, getByRole } = render(
+      <DownloadDropdowns
+        updaterAction={updater}
+        marketplace={false}
+        Table={Table}
+      />
+    );
+
+    expect(getByRole('option', { name: 'Mock_os' }).selected).toBeTruthy()
+  });
+
+  it('renders correctly - use URL param arch=mock_arch', async () => {
+    queryString.parse = vi.fn().mockReturnValue({'arch': "mock_arch"});
+
+    const { container, getByRole } = render(
+      <DownloadDropdowns
+        updaterAction={updater}
+        marketplace={false}
+        Table={Table}
+      />
+    );
+
+    expect(getByRole('option', { name: 'mock_arch' }).selected).toBeTruthy()
+  });
+
+  it('renders correctly - use URL param package=mock_pkg', async () => {
+    queryString.parse = vi.fn().mockReturnValue({'package': "mock_pkg"});
+
+    const { container, getByRole } = render(
+      <DownloadDropdowns
+        updaterAction={updater}
+        marketplace={false}
+        Table={Table}
+      />
+    );
+
+    expect(getByRole('option', { name: 'mock_pkg' }).selected).toBeTruthy()
+  });
+
+  it('renders correctly - use URL param version=2', async () => {
+    queryString.parse = vi.fn().mockReturnValue({'version': "2"});
+
+    const { container, getByRole } = render(
+      <DownloadDropdowns
+        updaterAction={updater}
+        marketplace={false}
+        Table={Table}
+      />
+    );
+
+    expect(getByRole('option', { name: '2' }).selected).toBeTruthy()
+  });
+
+  it('renders correctly - use URL param version=latest', async () => {
+    queryString.parse = vi.fn().mockReturnValue({'version': 'latest'});
+
+    const { container, getByRole } = render(
+      <DownloadDropdowns
+        updaterAction={updater}
+        marketplace={false}
+        Table={Table}
+      />
+    );
+
+    expect(getByRole('option', { name: '2' }).selected).toBeTruthy()
+  });
+
+  it('renders correctly - use URL paramvariant=openjdk2', async () => {
+    queryString.parse = vi.fn().mockReturnValue({'variant': "openjdk2"});
+
+    const { container, getByRole } = render(
+      <DownloadDropdowns
+        updaterAction={updater}
+        marketplace={false}
+        Table={Table}
+      />
+    );
+
+    expect(getByRole('option', { name: '2' }).selected).toBeTruthy()
   });
 
   it('renders correctly - marketplace', async () => {

--- a/src/components/DownloadDropdowns/__tests__/__snapshots__/DownloadDropdowns.test.tsx.snap
+++ b/src/components/DownloadDropdowns/__tests__/__snapshots__/DownloadDropdowns.test.tsx.snap
@@ -83,9 +83,9 @@ exports[`DownloadDropdowns component > renders correctly - marketplace 1`] = `
           Any
         </option>
         <option
-          value="mock_jdk"
+          value="mock_pkg"
         >
-          mock_jdk
+          mock_pkg
         </option>
       </select>
     </div>
@@ -198,9 +198,9 @@ exports[`DownloadDropdowns component > renders correctly 1`] = `
           Any
         </option>
         <option
-          value="mock_jdk"
+          value="mock_pkg"
         >
-          mock_jdk
+          mock_pkg
         </option>
       </select>
     </div>
@@ -220,14 +220,14 @@ exports[`DownloadDropdowns component > renders correctly 1`] = `
         id="version-filter"
       >
         <option
-          value="1"
-        >
-          1 - LTS
-        </option>
-        <option
           value="2"
         >
           2
+        </option>
+        <option
+          value="1"
+        >
+          1 - LTS
         </option>
       </select>
     </div>

--- a/src/components/DownloadDropdowns/index.tsx
+++ b/src/components/DownloadDropdowns/index.tsx
@@ -31,43 +31,65 @@ const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
       }
     `)
 
+    // prepare versions list
+    const versions = data.allVersions.edges;
+    let versionList = versions;
+
+    const queryStringParams = queryString.parse(useLocation().search);
+
     // init the default selected Operation System, if any from the param 'os'
     let defaultSelectedOS = 'any';
-    const osParam = queryString.parse(useLocation().search).os;
+    const osParam = queryStringParams.os;
     if (osParam) {
-        defaultSelectedOS = osParam.toString();
+        let sop = osParam.toString().toLowerCase();
+        if(oses.findIndex(os => os.toLowerCase() === sop) >= 0)
+            defaultSelectedOS = sop;
     }
 
     // init the default selected Architecture, if any from the param 'arch'
     let defaultSelectedArch = 'any';
-    const archParam = queryString.parse(useLocation().search).arch;
+    const archParam = queryStringParams.arch;
     if (archParam) {
-        defaultSelectedArch = archParam.toString();
+        let sap = archParam.toString().toLowerCase();
+        if(arches.findIndex(a => a.toLowerCase() === sap) >= 0)
+            defaultSelectedArch = sap;
     }
 
     // init the default selected Package Type, if any from the param 'package'
     let defaultSelectedPackageType = 'any';
-    const packageParam = queryString.parse(useLocation().search).package;
+    const packageParam = queryStringParams.package;
     if (packageParam) {
-        defaultSelectedPackageType = packageParam.toString();
+        let spp = packageParam.toString().toLowerCase();
+        if(packageTypes.findIndex(p => p.toLowerCase() === spp) >= 0)
+            defaultSelectedPackageType = spp;
     }
 
     // init the default selected Version, if any from the param 'version' or from 'variant'
     let defaultSelectedVersion = data.mostRecentLts.version;
-    const versionParam = queryString.parse(useLocation().search).version;
+    const versionParam = queryStringParams.version;
     if (versionParam) {
-        defaultSelectedVersion = Number(versionParam).toString();
+        let svp = versionParam.toString();
+        let nvp = Number(svp);
+
+        if(svp.toLowerCase() === 'latest') {
+            // get the latest version of the list
+            defaultSelectedVersion = versions.sort((a, b) => b.node.version === a.node.version)[0].node.version;
+        } else if(versions.findIndex(version => version.node.version === nvp) >= 0) {
+            defaultSelectedVersion = nvp;
+        }
     }
-    const variantParam = queryString.parse(useLocation().search).variant;
+
+    // init the default selected Version, if any from the param 'variant'
+    const variantParam = queryStringParams.variant;
     if (variantParam) {
         // convert openjdk11 to 11
         const parsedVersion = variantParam.toString().replace(/\D/g, '')
-        defaultSelectedVersion = parsedVersion;
-    }
+        let nvp = Number(parsedVersion);
 
-    // prepare versions list
-    const versions = data.allVersions.edges;
-    let versionList = versions;
+        if(versions.findIndex(version => version.node.version === nvp) >= 0) {
+            defaultSelectedVersion = nvp;
+        }
+    }
 
     if (marketplace) {
         // filter non LTS versions

--- a/src/components/DownloadDropdowns/index.tsx
+++ b/src/components/DownloadDropdowns/index.tsx
@@ -73,7 +73,7 @@ const DownloadDropdowns = ({updaterAction, marketplace, Table}) => {
 
         if(svp.toLowerCase() === 'latest') {
             // get the latest version of the list
-            defaultSelectedVersion = versions.sort((a, b) => b.node.version === a.node.version)[0].node.version;
+            defaultSelectedVersion = versions.sort((a, b) => b.node.version - a.node.version)[0].node.version;
         } else if(versions.findIndex(version => version.node.version === nvp) >= 0) {
             defaultSelectedVersion = nvp;
         }


### PR DESCRIPTION
# Description of change
This PR fix the issue #1564 - Support "latest" as version parameter on the Temurin releases page

It's now possible to have the url `https://adoptium.net/temurin/releases/?version=latest`

Additional fixes:
- ignore case of param values
- ignore values if do not exist in dropdowns


## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
