### PR TITLE
[adoptium-1643] Download page lack checksum info

### DIFF
--- a/src/components/LatestTemurin/index.tsx
+++ b/src/components/LatestTemurin/index.tsx
@@ -1,7 +1,6 @@
 import React, { MutableRefObject, useRef } from 'react';
 import { Link, Trans } from 'gatsby-plugin-react-i18next';
 import { FaArrowCircleRight, FaArchive, FaDownload } from 'react-icons/fa';
-
 import { detectOS, UserOS } from '../../util/detectOS';
 import { fetchLatestForOS, useOnScreen } from '../../hooks';
 
@@ -78,7 +77,7 @@ const LatestTemurin = (props): JSX.Element => {
         <div className={`btn-group-vertical mx-auto ${buttonClass}`}>
             {binary ? (
               <>
-                <Link to="/download" state={{ link: binary.link, os: userOSName, arch: arch, pkg_type: 'JDK', java_version: binary.release_name }} className="btn btn-lg btn-primary mt-3 py-3 text-white">
+                <Link to="/download" state={{ link: binary.link, checksum: binary.checksum, os: userOSName, arch: arch, pkg_type: 'JDK', java_version: binary.release_name }} className="btn btn-lg btn-primary mt-3 py-3 text-white">
                     <FaDownload /> <Trans>Latest LTS Release</Trans>
                     <br/>
                     <span style={{ fontSize: '.6em'}} className="font-weight-light">{binary.release_name}</span>

--- a/src/components/MarketplaceDownloadTable/index.tsx
+++ b/src/components/MarketplaceDownloadTable/index.tsx
@@ -118,7 +118,7 @@ const BinaryTable = ({ checksum, link, filename, os, arch, pkgType, javaVersion,
                 </tbody></table>
             </td>
             <td className="align-middle">
-                <Link to="/download" state={{ link: link, os: os, arch: arch, pkg_type: pkgType, java_version: javaVersion, vendor: vendor }} className="btn btn-primary" style={{width: "6em"}}>
+                <Link to="/download" state={{ link: link, checksum: checksum, os: os, arch: arch, pkg_type: pkgType, java_version: javaVersion, vendor: vendor }} className="btn btn-primary" style={{width: "6em"}}>
                     <FaDownload /> {fetchExtension(filename)}
                 </Link>
             </td>

--- a/src/components/TemurinArchiveTable/index.tsx
+++ b/src/components/TemurinArchiveTable/index.tsx
@@ -74,6 +74,7 @@ const TemurinArchiveTable = ({results, updatePage}) => {
                                                                                 {asset.installer_link ? (
                                                                                     <DownloadButton
                                                                                         link={asset.installer_link}
+                                                                                        checksum={asset.installer_checksum}
                                                                                         platform={key}
                                                                                         type={asset.type}
                                                                                         version={release.release_name}
@@ -95,6 +96,7 @@ const TemurinArchiveTable = ({results, updatePage}) => {
                                                                             <td style={{borderLeft: "1px solid rgb(221, 221, 221)", paddingLeft: "20px"}}>
                                                                                 <DownloadButton
                                                                                     link={asset.link}
+                                                                                    checksum={asset.checksum}
                                                                                     platform={key}
                                                                                     type={asset.type}
                                                                                     version={release.release_name}
@@ -138,6 +140,7 @@ export default TemurinArchiveTable;
 
 interface DownloadProps {
     link: URL;
+    checksum: string,
     type: string;
     size: number;
     platform: string;
@@ -145,11 +148,11 @@ interface DownloadProps {
     installer: boolean;
 }
 
-const DownloadButton = ({ link, type, size, platform, version, installer }: DownloadProps): null | JSX.Element => {
+const DownloadButton = ({ link, checksum, type, size, platform, version, installer }: DownloadProps): null | JSX.Element => {
     let os: string = capitalize(platform.split("-")[0])
     let arch: string = platform.split("-")[1]
     return (
-        <Link to="/download" state={{ link: link, os: os, arch: arch, pkg_type: type, java_version: version }} className="btn btn-primary" style={{width: "9em"}}>
+        <Link to="/download" state={{ link: link, checksum: checksum, os: os, arch: arch, pkg_type: type, java_version: version }} className="btn btn-primary" style={{width: "9em"}}>
             {type} {!installer ? (size + " MB") : ""}
         </Link>
     )

--- a/src/components/TemurinDownloadTable/index.tsx
+++ b/src/components/TemurinDownloadTable/index.tsx
@@ -123,7 +123,7 @@ const BinaryTable = ({ checksum, link, extension, type, size, os, arch, version 
                 </tbody></table>
             </td>
             <td className="align-middle">
-                <Link to="/download" state={{ link: link, os: os, arch: arch, pkg_type: type, java_version: version }} className="btn btn-primary" style={{width: "6em"}}>
+                <Link to="/download" state={{ link: link, checksum: checksum, os: os, arch: arch, pkg_type: type, java_version: version }} className="btn btn-primary" style={{width: "6em"}}>
                     <FaDownload /> {extension}
                 </Link>
             </td>

--- a/src/components/TemurinNightlyTable/index.tsx
+++ b/src/components/TemurinNightlyTable/index.tsx
@@ -33,9 +33,9 @@ const TemurinNightlyTable = ({results}) => {
                                                             <td>{capitalize(asset.os)} {asset.architecture === 'x32' ? 'x86' : asset.architecture}</td>
                                                             <td>{asset.type}</td>
                                                             <td>{localeDate(release.timestamp, language)}</td>
-                                                            <td><Link to="/download" state={{ link: asset.link, os: capitalize(key.split("-")[0]), arch: key.split("-")[1], pkg_type: asset.type, java_version: 'nightly' }}>{`${asset.extension} (${asset.size} MB)`}</Link></td>
+                                                            <td><Link to="/download" state={{ link: asset.link, checksum: asset.checksum, os: capitalize(key.split("-")[0]), arch: key.split("-")[1], pkg_type: asset.type, java_version: 'nightly' }}>{`${asset.extension} (${asset.size} MB)`}</Link></td>
                                                             {asset.installer_link ? (
-                                                                <td><Link to="/download" state={{ link: asset.installer_link }}>{asset.installer_extension}</Link></td>
+                                                                <td><Link to="/download" state={{ link: asset.installer_link, checksum: asset.installer_checksum }}>{asset.installer_extension}</Link></td>
                                                             ) :
                                                                 <td>Not Available</td>
                                                             }

--- a/src/hooks/__tests__/__snapshots__/fetchLatestTemurin.test.tsx.snap
+++ b/src/hooks/__tests__/__snapshots__/fetchLatestTemurin.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`fetchLatestForOS > binary URL is set correctly 1`] = `
 {
+  "checksum": "sha265sum_mock",
   "link": "https://link_mock/",
   "release_name": "release_name_mock",
 }
@@ -9,6 +10,7 @@ exports[`fetchLatestForOS > binary URL is set correctly 1`] = `
 
 exports[`fetchLatestForOS > installer is returned if available 1`] = `
 {
+  "checksum": "installer_sha265sum_mock",
   "link": "https://installer_link_mock/",
   "release_name": "release_name_mock",
 }

--- a/src/hooks/fetchLatestTemurin.tsx
+++ b/src/hooks/fetchLatestTemurin.tsx
@@ -29,18 +29,22 @@ async function fetchLatestForOSRequest(version: number, os: string, arch: string
     const response = await fetch(url);
     const json: LatestTemurin = (await response.json())[0];
     let binary_link = json.binaries[0].package.link
+    let binary_checksum = json.binaries[0].package.checksum
     if (json.binaries[0].installer) {
-        binary_link = json.binaries[0].installer.link
+        binary_link = json.binaries[0].installer.link,
+        binary_checksum = json.binaries[0].installer.checksum
     }
     return {
         release_name: json.release_name,
-        link: binary_link
+        link: binary_link,
+        checksum: binary_checksum,
     };
 }
 
 export interface Binary {
   release_name: string;
   link: URL;
+  checksum: string;
 }
 
 export interface LatestTemurin {

--- a/src/pages/__tests__/__snapshots__/download.test.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/download.test.tsx.snap
@@ -291,6 +291,93 @@ exports[`Download page > renders correctly 1`] = `
         </a>
       </div>
     </div>
+     <div
+       aria-hidden="true"
+       aria-labelledby="checksumModalLabel"
+       class="modal fade"
+       id="checksumModal"
+       style="z-index: 10000;"
+       tabindex="-1"
+     >
+       <div
+         class="modal-dialog modal-lg"
+       >
+         <div
+           class="modal-content"
+         >
+           <div
+             class="modal-header"
+           >
+             <h5
+               class="modal-title"
+               id="checksumModalLabel"
+             >
+               Checksum (SHA256)
+             </h5>
+             <button
+               aria-label="Close"
+               class="btn-close"
+               data-bs-dismiss="modal"
+               type="button"
+             />
+           </div>
+           <div
+             class="modal-body text-start"
+           >
+             <p>
+               The checksum is used to ensure the file has not been corrupted during download. You should compare the checksum of the file you received with the value below to ensure the file you received is complete and unmodified.
+             </p>
+             <p>
+               On Windows use 
+               <code>
+                 certUtil -hashfile 
+                 <var>
+                   file
+                 </var>
+                  SHA256
+               </code>
+               , on Linux use 
+               <code>
+                 sha256sum 
+                 <var>
+                   file
+                 </var>
+               </code>
+               , and on macOS use 
+               <code>
+                 shasum -a 256 
+                 <var>
+                   file
+                 </var>
+               </code>
+               .
+             </p>
+             <input
+               readonly=""
+               style="width: 100%;"
+               value=""
+             />
+           </div>
+           <div
+             class="modal-footer"
+           >
+             <button
+               class="btn btn-primary"
+               type="button"
+             >
+               Copy
+             </button>
+             <button
+               class="btn btn-secondary"
+               data-bs-dismiss="modal"
+               type="button"
+             >
+               Close
+             </button>
+           </div>
+         </div>
+       </div>
+     </div>
   </section>
 </main>
 `;

--- a/src/pages/__tests__/__snapshots__/download.test.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/download.test.tsx.snap
@@ -41,6 +41,38 @@ exports[`Download page > renders correctly - vendor 1`] = `
           </a>
           .
         </p>
+        <p
+          class="text-muted py-3"
+        >
+          <a
+            class="btn btn-lg btn-outline-dark m-2"
+            data-bs-checksum="sha265sum_mock"
+            data-bs-target="#checksumModal"
+            data-bs-toggle="modal"
+            href=""
+          >
+            <small>
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 16 16"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M5.338 1.59a61.44 61.44 0 0 0-2.837.856.481.481 0 0 0-.328.39c-.554 4.157.726 7.19 2.253 9.188a10.725 10.725 0 0 0 2.287 2.233c.346.244.652.42.893.533.12.057.218.095.293.118a.55.55 0 0 0 .101.025.615.615 0 0 0 .1-.025c.076-.023.174-.061.294-.118.24-.113.547-.29.893-.533a10.726 10.726 0 0 0 2.287-2.233c1.527-1.997 2.807-5.031 2.253-9.188a.48.48 0 0 0-.328-.39c-.651-.213-1.75-.56-2.837-.855C9.552 1.29 8.531 1.067 8 1.067c-.53 0-1.552.223-2.662.524zM5.072.56C6.157.265 7.31 0 8 0s1.843.265 2.928.56c1.11.3 2.229.655 2.887.87a1.54 1.54 0 0 1 1.044 1.262c.596 4.477-.787 7.795-2.465 9.99a11.775 11.775 0 0 1-2.517 2.453 7.159 7.159 0 0 1-1.048.625c-.28.132-.581.24-.829.24s-.548-.108-.829-.24a7.158 7.158 0 0 1-1.048-.625 11.777 11.777 0 0 1-2.517-2.453C1.928 10.487.545 7.169 1.141 2.692A1.54 1.54 0 0 1 2.185 1.43 62.456 62.456 0 0 1 5.072.56z"
+                />
+                <path
+                  d="M10.854 5.146a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708 0l-1.5-1.5a.5.5 0 1 1 .708-.708L7.5 7.793l2.646-2.647a.5.5 0 0 1 .708 0z"
+                />
+              </svg>
+               
+              Text
+            </small>
+          </a>
+        </p>
         <meta
           content="0; url=https://fake-download.tar.gz"
           http-equiv="refresh"
@@ -152,6 +184,93 @@ exports[`Download page > renders correctly - vendor 1`] = `
         </a>
       </div>
     </div>
+    <div
+      aria-hidden="true"
+      aria-labelledby="checksumModalLabel"
+      class="modal fade"
+      id="checksumModal"
+      style="z-index: 10000;"
+      tabindex="-1"
+    >
+      <div
+        class="modal-dialog modal-lg"
+      >
+        <div
+          class="modal-content"
+        >
+          <div
+            class="modal-header"
+          >
+            <h5
+              class="modal-title"
+              id="checksumModalLabel"
+            >
+              Checksum (SHA256)
+            </h5>
+            <button
+              aria-label="Close"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              type="button"
+            />
+          </div>
+          <div
+            class="modal-body text-start"
+          >
+            <p>
+              The checksum is used to ensure the file has not been corrupted during download. You should compare the checksum of the file you received with the value below to ensure the file you received is complete and unmodified.
+            </p>
+            <p>
+              On Windows use 
+              <code>
+                certUtil -hashfile 
+                <var>
+                  file
+                </var>
+                 SHA256
+              </code>
+              , on Linux use 
+              <code>
+                sha256sum 
+                <var>
+                  file
+                </var>
+              </code>
+              , and on macOS use 
+              <code>
+                shasum -a 256 
+                <var>
+                  file
+                </var>
+              </code>
+              .
+            </p>
+            <input
+              readonly=""
+              style="width: 100%;"
+              value=""
+            />
+          </div>
+          <div
+            class="modal-footer"
+          >
+            <button
+              class="btn btn-primary"
+              type="button"
+            >
+              Copy
+            </button>
+            <button
+              class="btn btn-secondary"
+              data-bs-dismiss="modal"
+              type="button"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   </section>
 </main>
 `;
@@ -176,6 +295,38 @@ exports[`Download page > renders correctly 1`] = `
           class="py-2"
         >
           You are downloading an Eclipse Temurin build, the open-source community build from the Eclipse Adoptium Working Group.
+        </p>
+        <p
+          class="text-muted py-3"
+        >
+          <a
+            class="btn btn-lg btn-outline-dark m-2"
+            data-bs-checksum="sha265sum_mock"
+            data-bs-target="#checksumModal"
+            data-bs-toggle="modal"
+            href=""
+          >
+            <small>
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 16 16"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M5.338 1.59a61.44 61.44 0 0 0-2.837.856.481.481 0 0 0-.328.39c-.554 4.157.726 7.19 2.253 9.188a10.725 10.725 0 0 0 2.287 2.233c.346.244.652.42.893.533.12.057.218.095.293.118a.55.55 0 0 0 .101.025.615.615 0 0 0 .1-.025c.076-.023.174-.061.294-.118.24-.113.547-.29.893-.533a10.726 10.726 0 0 0 2.287-2.233c1.527-1.997 2.807-5.031 2.253-9.188a.48.48 0 0 0-.328-.39c-.651-.213-1.75-.56-2.837-.855C9.552 1.29 8.531 1.067 8 1.067c-.53 0-1.552.223-2.662.524zM5.072.56C6.157.265 7.31 0 8 0s1.843.265 2.928.56c1.11.3 2.229.655 2.887.87a1.54 1.54 0 0 1 1.044 1.262c.596 4.477-.787 7.795-2.465 9.99a11.775 11.775 0 0 1-2.517 2.453 7.159 7.159 0 0 1-1.048.625c-.28.132-.581.24-.829.24s-.548-.108-.829-.24a7.158 7.158 0 0 1-1.048-.625 11.777 11.777 0 0 1-2.517-2.453C1.928 10.487.545 7.169 1.141 2.692A1.54 1.54 0 0 1 2.185 1.43 62.456 62.456 0 0 1 5.072.56z"
+                />
+                <path
+                  d="M10.854 5.146a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708 0l-1.5-1.5a.5.5 0 1 1 .708-.708L7.5 7.793l2.646-2.647a.5.5 0 0 1 .708 0z"
+                />
+              </svg>
+               
+              Text
+            </small>
+          </a>
         </p>
         <meta
           content="0; url=https://fake-download.tar.gz"
@@ -291,93 +442,93 @@ exports[`Download page > renders correctly 1`] = `
         </a>
       </div>
     </div>
-     <div
-       aria-hidden="true"
-       aria-labelledby="checksumModalLabel"
-       class="modal fade"
-       id="checksumModal"
-       style="z-index: 10000;"
-       tabindex="-1"
-     >
-       <div
-         class="modal-dialog modal-lg"
-       >
-         <div
-           class="modal-content"
-         >
-           <div
-             class="modal-header"
-           >
-             <h5
-               class="modal-title"
-               id="checksumModalLabel"
-             >
-               Checksum (SHA256)
-             </h5>
-             <button
-               aria-label="Close"
-               class="btn-close"
-               data-bs-dismiss="modal"
-               type="button"
-             />
-           </div>
-           <div
-             class="modal-body text-start"
-           >
-             <p>
-               The checksum is used to ensure the file has not been corrupted during download. You should compare the checksum of the file you received with the value below to ensure the file you received is complete and unmodified.
-             </p>
-             <p>
-               On Windows use 
-               <code>
-                 certUtil -hashfile 
-                 <var>
-                   file
-                 </var>
-                  SHA256
-               </code>
-               , on Linux use 
-               <code>
-                 sha256sum 
-                 <var>
-                   file
-                 </var>
-               </code>
-               , and on macOS use 
-               <code>
-                 shasum -a 256 
-                 <var>
-                   file
-                 </var>
-               </code>
-               .
-             </p>
-             <input
-               readonly=""
-               style="width: 100%;"
-               value=""
-             />
-           </div>
-           <div
-             class="modal-footer"
-           >
-             <button
-               class="btn btn-primary"
-               type="button"
-             >
-               Copy
-             </button>
-             <button
-               class="btn btn-secondary"
-               data-bs-dismiss="modal"
-               type="button"
-             >
-               Close
-             </button>
-           </div>
-         </div>
-       </div>
-     </div>
+    <div
+      aria-hidden="true"
+      aria-labelledby="checksumModalLabel"
+      class="modal fade"
+      id="checksumModal"
+      style="z-index: 10000;"
+      tabindex="-1"
+    >
+      <div
+        class="modal-dialog modal-lg"
+      >
+        <div
+          class="modal-content"
+        >
+          <div
+            class="modal-header"
+          >
+            <h5
+              class="modal-title"
+              id="checksumModalLabel"
+            >
+              Checksum (SHA256)
+            </h5>
+            <button
+              aria-label="Close"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              type="button"
+            />
+          </div>
+          <div
+            class="modal-body text-start"
+          >
+            <p>
+              The checksum is used to ensure the file has not been corrupted during download. You should compare the checksum of the file you received with the value below to ensure the file you received is complete and unmodified.
+            </p>
+            <p>
+              On Windows use 
+              <code>
+                certUtil -hashfile 
+                <var>
+                  file
+                </var>
+                 SHA256
+              </code>
+              , on Linux use 
+              <code>
+                sha256sum 
+                <var>
+                  file
+                </var>
+              </code>
+              , and on macOS use 
+              <code>
+                shasum -a 256 
+                <var>
+                  file
+                </var>
+              </code>
+              .
+            </p>
+            <input
+              readonly=""
+              style="width: 100%;"
+              value=""
+            />
+          </div>
+          <div
+            class="modal-footer"
+          >
+            <button
+              class="btn btn-primary"
+              type="button"
+            >
+              Copy
+            </button>
+            <button
+              class="btn btn-secondary"
+              data-bs-dismiss="modal"
+              type="button"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   </section>
 </main>
 `;

--- a/src/pages/__tests__/download.test.tsx
+++ b/src/pages/__tests__/download.test.tsx
@@ -7,6 +7,7 @@ import Download, { Head } from '../download';
 const location = {
   state: {
     link: 'https://fake-download.tar.gz',
+    checksum: 'sha265sum_mock',
     os: 'linux',
     arch: 'x64',
     type: 'jdk',
@@ -43,6 +44,7 @@ describe('Download page', () => {
     const location = {
       state: {
         link: 'https://fake-download.tar.gz',
+        checksum: 'sha265sum_mock',
         os: 'linux',
         arch: 'x64',
         java_version: '1.0.0',

--- a/src/pages/download.tsx
+++ b/src/pages/download.tsx
@@ -2,15 +2,18 @@ import React, { useEffect } from 'react'
 import { Link, graphql, navigate } from 'gatsby'
 import { BiDonateHeart } from 'react-icons/bi'
 import { SiGithubsponsors } from 'react-icons/si'
-
 import vendors from '../json/marketplace.json'
 import Layout from '../components/Layout'
 import Seo from '../components/Seo'
+import { BsShieldCheck } from 'react-icons/bs'
+import { Trans } from 'gatsby-plugin-react-i18next';
+import ChecksumModal from '../components/ChecksumModal'
 
 const DownloadPage = ({ location }) => {
-  let link, os, arch, type, version, vendor, postDownload
+  let link, checksum, os, arch, type, version, vendor, postDownload;
   if (location.state && location.state.link) {
     link = location.state.link
+    checksum = location.state.checksum
     os = location.state.os
     arch = location.state.arch
     type = location.state.pkg_type
@@ -66,6 +69,19 @@ const DownloadPage = ({ location }) => {
                   )
             )}
 
+            {checksum &&
+              <>
+                <p className='text-muted py-3'>
+                   <a href="" className='btn btn-lg btn-outline-dark m-2'
+                        data-bs-toggle="modal"
+                        data-bs-target="#checksumModal"
+                        data-bs-checksum={checksum}>
+                        <small><BsShieldCheck/> <Trans>View checksum file</Trans></small>
+                    </a>
+                </p>
+              </>
+            }
+
             {link &&
               <>
                 <meta httpEquiv='refresh' content={`0; url=${link}`} />
@@ -85,6 +101,7 @@ const DownloadPage = ({ location }) => {
             <Link to='/members' className='btn btn-lg btn-primary m-2'>View our Members</Link>
           </div>
         </div>
+        <ChecksumModal />
       </section>
     </Layout>
   )


### PR DESCRIPTION
# Description of change
This pull request is to fix the _lack of checksum info on the download page_ reported in issue #1643 

What it looks like:
![image](https://github.com/adoptium/adoptium.net/assets/3774556/79c85790-357d-4680-b956-1710ef9dd5a4)

## Checklist
- [x] `npm test` passes
