### PR TITLE
update vitest-axe to 1.0.0-pre.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
         "prettier": "3.0.2",
         "react-test-renderer": "^18.2.0",
         "vitest": "^0.34.2",
-        "vitest-axe": "^0.1.0",
+        "vitest-axe": "^1.0.0-pre.0",
         "vitest-canvas-mock": "^0.3.3"
       }
     },
@@ -7048,11 +7048,11 @@
       }
     },
     "node_modules/aria-query": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dependencies": {
-        "deep-equal": "^2.0.5"
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/arity-n": {
@@ -7395,9 +7395,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.3.tgz",
-      "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
+      "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
       "engines": {
         "node": ">=4"
       }
@@ -9876,9 +9876,9 @@
       }
     },
     "node_modules/dom-accessibility-api": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz",
-      "integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true
     },
     "node_modules/dom-converter": {
@@ -26285,32 +26285,75 @@
       }
     },
     "node_modules/vitest-axe": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/vitest-axe/-/vitest-axe-0.1.0.tgz",
-      "integrity": "sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==",
+      "version": "1.0.0-pre.0",
+      "resolved": "https://registry.npmjs.org/vitest-axe/-/vitest-axe-1.0.0-pre.0.tgz",
+      "integrity": "sha512-q6/H+pgPXGlAaQv9hrxBwR/s6Xxptwq/dsyW6G2E8peZK+j/AEN3wiwWcTHyhDWBZ3RN9vPC56MNcbGl1gYZ5g==",
       "dev": true,
       "dependencies": {
-        "aria-query": "^5.0.0",
-        "axe-core": "^4.4.2",
-        "chalk": "^5.0.1",
-        "dom-accessibility-api": "^0.5.14",
+        "aria-query": "^5.3.0",
+        "axe-core": "^4.7.2",
+        "chalk": "^5.3.0",
+        "dom-accessibility-api": "^0.5.16",
         "lodash-es": "^4.17.21",
-        "redent": "^3.0.0"
+        "redent": "^4.0.0"
       },
       "peerDependencies": {
-        "vitest": ">=0.16.0"
+        "vitest": ">=0.31.0"
       }
     },
     "node_modules/vitest-axe/node_modules/chalk": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "dev": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/vitest-axe/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest-axe/node_modules/redent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
+      "integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^5.0.0",
+        "strip-indent": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest-axe/node_modules/strip-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
+      "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/vitest-canvas-mock": {
@@ -32147,11 +32190,11 @@
       }
     },
     "aria-query": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "requires": {
-        "deep-equal": "^2.0.5"
+        "dequal": "^2.0.3"
       }
     },
     "arity-n": {
@@ -32378,9 +32421,9 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "axe-core": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.3.tgz",
-      "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg=="
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
+      "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g=="
     },
     "axios": {
       "version": "0.21.4",
@@ -34250,9 +34293,9 @@
       }
     },
     "dom-accessibility-api": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz",
-      "integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true
     },
     "dom-converter": {
@@ -46137,24 +46180,49 @@
       }
     },
     "vitest-axe": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/vitest-axe/-/vitest-axe-0.1.0.tgz",
-      "integrity": "sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==",
+      "version": "1.0.0-pre.0",
+      "resolved": "https://registry.npmjs.org/vitest-axe/-/vitest-axe-1.0.0-pre.0.tgz",
+      "integrity": "sha512-q6/H+pgPXGlAaQv9hrxBwR/s6Xxptwq/dsyW6G2E8peZK+j/AEN3wiwWcTHyhDWBZ3RN9vPC56MNcbGl1gYZ5g==",
       "dev": true,
       "requires": {
-        "aria-query": "^5.0.0",
-        "axe-core": "^4.4.2",
-        "chalk": "^5.0.1",
-        "dom-accessibility-api": "^0.5.14",
+        "aria-query": "^5.3.0",
+        "axe-core": "^4.7.2",
+        "chalk": "^5.3.0",
+        "dom-accessibility-api": "^0.5.16",
         "lodash-es": "^4.17.21",
-        "redent": "^3.0.0"
+        "redent": "^4.0.0"
       },
       "dependencies": {
         "chalk": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-          "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
           "dev": true
+        },
+        "indent-string": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+          "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+          "dev": true
+        },
+        "redent": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
+          "integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
+          "dev": true,
+          "requires": {
+            "indent-string": "^5.0.0",
+            "strip-indent": "^4.0.0"
+          }
+        },
+        "strip-indent": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
+          "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
+          "dev": true,
+          "requires": {
+            "min-indent": "^1.0.1"
+          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,6 @@
         "@types/prismjs": "^1.26.0",
         "@types/react": "^18.2.21",
         "@types/react-dom": "^18.2.7",
-        "@types/react-test-renderer": "^18.0.0",
         "@types/react-world-flags": "^1.4.2",
         "@types/testing-library__jest-dom": "^6.0.0",
         "@vitejs/plugin-react": "^4.0.4",
@@ -92,7 +91,6 @@
         "identity-obj-proxy": "^3.0.0",
         "jsdom": "^22.1.0",
         "prettier": "3.0.2",
-        "react-test-renderer": "^18.2.0",
         "vitest": "^0.34.2",
         "vitest-axe": "^1.0.0-pre.0",
         "vitest-canvas-mock": "^0.3.3"
@@ -6080,15 +6078,6 @@
       "version": "18.2.1",
       "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-18.2.1.tgz",
       "integrity": "sha512-wyUkmaaSZEzFZivD8F2ftSyAfk6L+DfFliVj/mYdOXbVjRcS87fQJLTnhk6dRZPuJjI+9g6RZJO4PNCngUrmyw==",
-      "dependencies": {
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-test-renderer": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-18.0.0.tgz",
-      "integrity": "sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==",
-      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -21977,19 +21966,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/react-shallow-renderer": {
-      "version": "16.15.0",
-      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
-      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
-      "dev": true,
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/react-share": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/react-share/-/react-share-4.4.1.tgz",
@@ -22037,26 +22013,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/react-test-renderer": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
-      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
-      "dev": true,
-      "dependencies": {
-        "react-is": "^18.2.0",
-        "react-shallow-renderer": "^16.15.0",
-        "scheduler": "^0.23.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/react-test-renderer/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
@@ -31443,15 +31399,6 @@
       "version": "18.2.1",
       "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-18.2.1.tgz",
       "integrity": "sha512-wyUkmaaSZEzFZivD8F2ftSyAfk6L+DfFliVj/mYdOXbVjRcS87fQJLTnhk6dRZPuJjI+9g6RZJO4PNCngUrmyw==",
-      "requires": {
-        "@types/react": "*"
-      }
-    },
-    "@types/react-test-renderer": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-18.0.0.tgz",
-      "integrity": "sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==",
-      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -42985,16 +42932,6 @@
         }
       }
     },
-    "react-shallow-renderer": {
-      "version": "16.15.0",
-      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
-      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
-      "dev": true,
-      "requires": {
-        "object-assign": "^4.1.1",
-        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "react-share": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/react-share/-/react-share-4.4.1.tgz",
@@ -43025,25 +42962,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
           "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q=="
-        }
-      }
-    },
-    "react-test-renderer": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
-      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
-      "dev": true,
-      "requires": {
-        "react-is": "^18.2.0",
-        "react-shallow-renderer": "^16.15.0",
-        "scheduler": "^0.23.0"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "@types/prismjs": "^1.26.0",
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
-    "@types/react-test-renderer": "^18.0.0",
     "@types/react-world-flags": "^1.4.2",
     "@types/testing-library__jest-dom": "^6.0.0",
     "@vitejs/plugin-react": "^4.0.4",
@@ -88,7 +87,6 @@
     "identity-obj-proxy": "^3.0.0",
     "jsdom": "^22.1.0",
     "prettier": "3.0.2",
-    "react-test-renderer": "^18.2.0",
     "vitest": "^0.34.2",
     "vitest-axe": "^1.0.0-pre.0",
     "vitest-canvas-mock": "^0.3.3"

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "prettier": "3.0.2",
     "react-test-renderer": "^18.2.0",
     "vitest": "^0.34.2",
-    "vitest-axe": "^0.1.0",
+    "vitest-axe": "^1.0.0-pre.0",
     "vitest-canvas-mock": "^0.3.3"
   },
   "overrides": {

--- a/src/components/DownloadDropdowns/__tests__/DownloadDropdowns.test.tsx
+++ b/src/components/DownloadDropdowns/__tests__/DownloadDropdowns.test.tsx
@@ -103,13 +103,16 @@ describe('DownloadDropdowns component', () => {
   it('renders correctly - use URL param os=mock_os', async () => {
     queryString.parse = vi.fn().mockReturnValue({'os': "mock_os"});
 
-    const { container, getByRole } = render(
-      <DownloadDropdowns
-        updaterAction={updater}
-        marketplace={false}
-        Table={Table}
-      />
-    );
+    let getByRole;
+    await act(async () => {
+      ({ getByRole } = render(
+        <DownloadDropdowns
+          updaterAction={updater}
+          marketplace={false}
+          Table={Table}
+        />
+      ));
+    });
 
     expect(getByRole('option', { name: 'Mock_os' }).selected).toBeTruthy()
   });
@@ -117,13 +120,16 @@ describe('DownloadDropdowns component', () => {
   it('renders correctly - use URL param arch=mock_arch', async () => {
     queryString.parse = vi.fn().mockReturnValue({'arch': "mock_arch"});
 
-    const { container, getByRole } = render(
-      <DownloadDropdowns
-        updaterAction={updater}
-        marketplace={false}
-        Table={Table}
-      />
-    );
+    let getByRole;
+    await act(async () => {
+      ({ getByRole } = render(
+        <DownloadDropdowns
+          updaterAction={updater}
+          marketplace={false}
+          Table={Table}
+        />
+      ));
+    });
 
     expect(getByRole('option', { name: 'mock_arch' }).selected).toBeTruthy()
   });
@@ -131,13 +137,16 @@ describe('DownloadDropdowns component', () => {
   it('renders correctly - use URL param package=mock_pkg', async () => {
     queryString.parse = vi.fn().mockReturnValue({'package': "mock_pkg"});
 
-    const { container, getByRole } = render(
-      <DownloadDropdowns
-        updaterAction={updater}
-        marketplace={false}
-        Table={Table}
-      />
-    );
+    let getByRole;
+    await act(async () => {
+      ({ getByRole } = render(
+        <DownloadDropdowns
+          updaterAction={updater}
+          marketplace={false}
+          Table={Table}
+        />
+      ));
+    });
 
     expect(getByRole('option', { name: 'mock_pkg' }).selected).toBeTruthy()
   });
@@ -145,13 +154,16 @@ describe('DownloadDropdowns component', () => {
   it('renders correctly - use URL param version=2', async () => {
     queryString.parse = vi.fn().mockReturnValue({'version': "2"});
 
-    const { container, getByRole } = render(
-      <DownloadDropdowns
-        updaterAction={updater}
-        marketplace={false}
-        Table={Table}
-      />
-    );
+    let getByRole;
+    await act(async () => {
+      ({ getByRole } = render(
+        <DownloadDropdowns
+          updaterAction={updater}
+          marketplace={false}
+          Table={Table}
+        />
+      ));
+    });
 
     expect(getByRole('option', { name: '2' }).selected).toBeTruthy()
   });
@@ -159,13 +171,16 @@ describe('DownloadDropdowns component', () => {
   it('renders correctly - use URL param version=latest', async () => {
     queryString.parse = vi.fn().mockReturnValue({'version': 'latest'});
 
-    const { container, getByRole } = render(
-      <DownloadDropdowns
-        updaterAction={updater}
-        marketplace={false}
-        Table={Table}
-      />
-    );
+    let getByRole;
+    await act(async () => {
+      ({ getByRole } = render(
+        <DownloadDropdowns
+          updaterAction={updater}
+          marketplace={false}
+          Table={Table}
+        />
+      ));
+    });
 
     expect(getByRole('option', { name: '2' }).selected).toBeTruthy()
   });
@@ -173,13 +188,16 @@ describe('DownloadDropdowns component', () => {
   it('renders correctly - use URL paramvariant=openjdk2', async () => {
     queryString.parse = vi.fn().mockReturnValue({'variant': "openjdk2"});
 
-    const { container, getByRole } = render(
-      <DownloadDropdowns
-        updaterAction={updater}
-        marketplace={false}
-        Table={Table}
-      />
-    );
+    let getByRole;
+    await act(async () => {
+      ({ getByRole } = render(
+        <DownloadDropdowns
+          updaterAction={updater}
+          marketplace={false}
+          Table={Table}
+        />
+      ));
+    });
 
     expect(getByRole('option', { name: '2' }).selected).toBeTruthy()
   });

--- a/src/components/DownloadDropdowns/__tests__/DownloadDropdowns.test.tsx
+++ b/src/components/DownloadDropdowns/__tests__/DownloadDropdowns.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { act, render, fireEvent, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { act } from '@testing-library/react';
 import { createRandomTemurinReleases } from '../../../__fixtures__/hooks';
 import DownloadDropdowns from '..';
 import queryString from 'query-string';

--- a/src/components/DownloadDropdowns/__tests__/DownloadDropdowns.test.tsx
+++ b/src/components/DownloadDropdowns/__tests__/DownloadDropdowns.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { act } from 'react-test-renderer';
+import { act } from '@testing-library/react';
 import { createRandomTemurinReleases } from '../../../__fixtures__/hooks';
 import DownloadDropdowns from '..';
 import queryString from 'query-string';

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -1,10 +1,6 @@
 import { expect, vi } from 'vitest'
 import * as axeMatchers from 'vitest-axe/matchers'
 import React from 'react'
-import { configure } from '@testing-library/dom';
-configure({
-  computedStyleSupportsPseudoElements: true
-})
 import 'vitest-axe/extend-expect'
 import '@testing-library/jest-dom'
 import 'vitest-canvas-mock'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,8 +16,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    deps: {
-      inline: ['vitest-canvas-mock'],
+    optimizer: {
+      web: {
+        include: ['vitest-canvas-mock'],
+      }
     },
     setupFiles: './vitest-setup.ts',
     coverage: {


### PR DESCRIPTION
# Description of change
Update vitest-axe to 1.0.0-pre.0 to validate the fixes I made upstream at https://github.com/chaance/vitest-axe/pull/5.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
