### PR TITLE
blog: Update EA blog to include JDK22 as well as 21

### DIFF
--- a/content/blog/early-access-builds/index.md
+++ b/content/blog/early-access-builds/index.md
@@ -1,14 +1,14 @@
 ---
-title: Early access builds for JDK21
+title: Early access builds for JDK21+
 date: "2023-08-14T14:00:00+00:00"
 author: sxa
-description: Adoptium are publishing early access "tagged" builds instead of nightlies for JDK21
+description: Adoptium are publishing early access "tagged" builds instead of nightlies for JDK21+
 tags:
   - temurin
 ---
 In addition to the generally available release builds of all currently supported
 versions of openjdk (Currently 8, 11, 17 and 20) Temurin also publishes "nightly"
-development builds of all of those streams as well as the upcoming release (JDK21
+development builds of all of those streams as well as the upcoming releases (JDK21/22
 at the moment) as "nightly" or "early access" builds. You can get these from
 [the nightly downloads page](https://adoptium.net/temurin/nightly/?version=21)
 or from the API. Note that while these are
@@ -16,15 +16,15 @@ not intended for production use they can be used to test a build containing any
 new fixes which have been put into openjdk along with any new features that
 will be coming in the next release.
 
-## Early access (ea) tagged builds of JDK21
+## Early access (ea) tagged builds of JDK21+
 
-We have recently changed the way we do the regular nightly builds of JDK21.
+We have recently changed the way we do the regular nightly builds of JDK21+.
 Instead of producing regular builds of the latest development code, we are
 building explicitly from the early access tags when they come out.  This is
 consistent with what OpenJDK does with the builds at
 https://jdk.java.net/21/ but on a wider range of platforms.  Similar to the
 nightly builds mentioned in the introduction, these are not for production
-use but may be useful for testing new features as they go into the JDK21
+use but may be useful for testing new features as they go into the new
 codebase.  By using the specific early access tags you can also report
 issues upstream more easily by knowing exactly which tagged level you have
 discovered any problems with.


### PR DESCRIPTION
# Description of change
<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->
Since JDK21 is no longer receiving regular updates and is not running any new ea builds, it makes sense to have JDk22 references in this blog post, as that's the one that has builds that are being actively published as ea builds.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
