### PR TITLE
[adoptium.net-1508] Release notes: filters contains only available values

### DIFF
--- a/src/components/ReleaseNotesRender/index.tsx
+++ b/src/components/ReleaseNotesRender/index.tsx
@@ -119,19 +119,19 @@ const ReleaseNotesRender = (): null | JSX.Element => {
   });
 
   if(releaseNotes && Array.isArray(releaseNotes.release_notes)) {
-    let priorities: string[]= [];
-    let types: string[]= [];
-    let components: string[]= [];
+    let priorities: string[] = [];
+    let types: string[] = [];
+    let components: string[] = [];
 
     releaseNotes.release_notes.forEach(release_note => {
-      if(release_note.priority) priorities.push(release_note.priority);
-      if(release_note.type) types.push(release_note.type);
-      if(release_note.component) components.push(release_note.component);
+      if(release_note.priority && priorities.indexOf(release_note.priority) < 0) priorities.push(release_note.priority);
+      if(release_note.type && types.indexOf(release_note.type) < 0) types.push(release_note.type);
+      if(release_note.component && components.indexOf(release_note.component) < 0) components.push(release_note.component);
     });
 
-    Array.prototype.push.apply(priorityValueOptions, [...new Set(priorities)]);
-    Array.prototype.push.apply(typeValueOptions, [...new Set(types)]);
-    Array.prototype.push.apply(componentValueOptions, [...new Set(components)]);
+    Array.prototype.push.apply(priorityValueOptions, priorities.sort((a, b) => a.localeCompare(b)));
+    Array.prototype.push.apply(typeValueOptions, types.sort((a, b) => a.localeCompare(b)));
+    Array.prototype.push.apply(componentValueOptions, components.sort((a, b) => a.localeCompare(b)));
   }
 
   interface FilterItem {

--- a/src/components/ReleaseNotesRender/index.tsx
+++ b/src/components/ReleaseNotesRender/index.tsx
@@ -129,8 +129,11 @@ const ReleaseNotesRender = (): null | JSX.Element => {
       if(release_note.component && components.indexOf(release_note.component) < 0) components.push(release_note.component);
     });
 
+    priorityValueOptions.splice(0);
     Array.prototype.push.apply(priorityValueOptions, priorities.sort((a, b) => a.localeCompare(b)));
+    typeValueOptions.splice(0);
     Array.prototype.push.apply(typeValueOptions, types.sort((a, b) => a.localeCompare(b)));
+    componentValueOptions.splice(0);
     Array.prototype.push.apply(componentValueOptions, components.sort((a, b) => a.localeCompare(b)));
   }
 

--- a/src/components/ReleaseNotesRender/index.tsx
+++ b/src/components/ReleaseNotesRender/index.tsx
@@ -54,12 +54,16 @@ const CustomToolbar: React.FunctionComponent<{
   </GridToolbarContainer>
 );
 
+const priorityValueOptions = [];
+const typeValueOptions = [];
+const componentValueOptions = [];
+
 const columns: GridColDef[] = [
   {
     field: 'priority',
-    type: 'singleSelect',
-    valueOptions: ['1', '2', '3', '4', '5'],
     headerName: 'Priority',
+    type: 'singleSelect',
+    valueOptions: priorityValueOptions,
     width: 100,
     renderCell: (params) => {
       const title = fetchTitle(params.value);
@@ -71,10 +75,9 @@ const columns: GridColDef[] = [
   },
   {
     field: 'type',
-    type: 'singleSelect',
-    // TODO: This needs automatically setting
-    valueOptions: ['Backport', 'Bug', 'Enhancement'],
     headerName: 'Type',
+    type: 'singleSelect',
+    valueOptions: typeValueOptions,
     width: 100,
     sortable: false,
     renderCell: (params) => (
@@ -84,6 +87,8 @@ const columns: GridColDef[] = [
   {
     field: 'component',
     headerName: 'Component',
+    type: 'singleSelect',
+    valueOptions: componentValueOptions,
     width: 150,
     sortable: false
   },
@@ -112,6 +117,22 @@ const ReleaseNotesRender = (): null | JSX.Element => {
       note.priority = '6';
     }
   });
+
+  if(releaseNotes && Array.isArray(releaseNotes.release_notes)) {
+    let priorities: string[]= [];
+    let types: string[]= [];
+    let components: string[]= [];
+
+    releaseNotes.release_notes.forEach(release_note => {
+      if(release_note.priority) priorities.push(release_note.priority);
+      if(release_note.type) types.push(release_note.type);
+      if(release_note.component) components.push(release_note.component);
+    });
+
+    Array.prototype.push.apply(priorityValueOptions, [...new Set(priorities)]);
+    Array.prototype.push.apply(typeValueOptions, [...new Set(types)]);
+    Array.prototype.push.apply(componentValueOptions, [...new Set(components)]);
+  }
 
   interface FilterItem {
     field: string;


### PR DESCRIPTION
# Description of change
This PR is to fix the point 12 of the issue adoptium/adoptium.net-redesign#1179 

In the header of the table, Release notes can be filtered.
With this modifications, only available values for priority / type / component fileds are displayed.


## Checklist
- [x] `npm test` passes
