### PR TITLE
Pass GH token to python script

### DIFF
--- a/.github/workflows/locale-checker.yml
+++ b/.github/workflows/locale-checker.yml
@@ -28,3 +28,5 @@ jobs:
 
       - name: Check asciidoc docs
         run: python3 .github/workflows/locale-checker.py
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description of change
Fixes: gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
