### PR TITLE
[adoptium.net-2239] sometimes the contributor component is empty

### DIFF
--- a/src/hooks/useAdoptiumContributorsApi.tsx
+++ b/src/hooks/useAdoptiumContributorsApi.tsx
@@ -96,10 +96,12 @@ async function fetchRandomContributor() {
   let needToRefetch = false;
   const ONE_MONTH_MS = 2592000000;
 
+  const wlsMaxContributors = `${repoToCheck}_max_contributors`;
+  const wlsFetchDate = `${repoToCheck}_fetch_date`;
+
   if (window.localStorage) {
-    const maxContributorsStored =
-      window.localStorage.getItem('max_contributors');
-    const fetchDateStored = window.localStorage.getItem('fetch_date');
+    const maxContributorsStored = window.localStorage.getItem(wlsMaxContributors);
+    const fetchDateStored = window.localStorage.getItem(wlsFetchDate);
 
     maxContributors = maxContributorsStored
       ? parseInt(maxContributorsStored, 10)
@@ -126,8 +128,8 @@ async function fetchRandomContributor() {
     }
 
     if (window.localStorage) {
-      window.localStorage.setItem('fetch_date', String(Date.now()));
-      window.localStorage.setItem('max_contributors', String(lastPage));
+      window.localStorage.setItem(wlsFetchDate, String(Date.now()));
+      window.localStorage.setItem(wlsMaxContributors, String(lastPage));
     }
 
     return contributor;


### PR DESCRIPTION
# Description of change
Reported issue is https://github.com/adoptium/adoptium.net-redesign/issues/1133

To fix the problem of empty contributor component, we have to store (in window.localStorage) information about
the current repository (repoToCheck). Else we are trying to retrieve a random page of a smaller repository.

## Checklist
- [x] `npm test` passes
