### PR TITLE
Update security update schedule

### DIFF
--- a/content/asciidoc-pages/support/index.adoc
+++ b/content/asciidoc-pages/support/index.adoc
@@ -34,7 +34,7 @@ dependencies.
 OpenJDK provide a new feature release every six months, and a
 maintenance/security update based upon each active release every three
 months. The release dates for those from the OpenJDK project are typically the
-https://www.oracle.com/security-alerts/[Tuesdays closest to the 17th] of
+https://www.oracle.com/security-alerts/[third Tuesday] of
 January, April, July and October. We will follow this schedule for
 publishing binary releases from Adoptium to ensure you get the latest,
 most secure builds.


### PR DESCRIPTION
# Description of change
<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

At some point, Oracle changed the release cadence for critical patch updates from the Tuesday closest to the 17th of the month to the third Tuesday of the month ([ref](https://www.oracle.com/security-alerts/), retrieved 2023 September 23). Update the support document to reflect this.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
