### PR TITLE
fix SSRProvider warning on build

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,29 +1,26 @@
 import * as React from 'react'
 import PropTypes from 'prop-types'
 import { Slice } from 'gatsby'
-import SSRProvider from 'react-bootstrap/SSRProvider'
 
 import './layout.scss'
 
 const Layout = ({ children }) => {
   return (
-    <SSRProvider>
-      <div
-        className='container-fluid p-0'
-        style={{
-          backgroundColor: 'var(--bg)',
-          color: 'var(--text-normal)',
-          transition: 'color 0.2s ease-out, background 0.2s ease-out'
-        }}
-      >
-        <Slice alias='navbar' />
-        <Slice alias='banner' />
-        <main>
-          {children}
-        </main>
-        <Slice alias='footer' />
-      </div>
-    </SSRProvider>
+    <div
+      className='container-fluid p-0'
+      style={{
+        backgroundColor: 'var(--bg)',
+        color: 'var(--text-normal)',
+        transition: 'color 0.2s ease-out, background 0.2s ease-out'
+      }}
+    >
+      <Slice alias='navbar' />
+      <Slice alias='banner' />
+      <main>
+        {children}
+      </main>
+      <Slice alias='footer' />
+    </div>
   )
 }
 


### PR DESCRIPTION
# Description of change

Fixes:
```
warning In React 18, SSRProvider is not necessary and is a noop. You can remove it from your app.
```

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
