### PR TITLE
Fix a translation error in French

### DIFF
--- a/locales/fr/asciidoc.json
+++ b/locales/fr/asciidoc.json
@@ -6,5 +6,5 @@
     "asciidoc.edit.link.content": "Tous les documents Adoptium sont open source. Vous voyez quelque chose qui ne va pas ou qui n'est pas clair ?",
     "asciidoc.edit.link.button": "Modifier cette page",
     "asciidoc.table.of.contents": "Table des matières",
-    "asciidoc.random.contributor.text": "Merci <profileUri>{{login}}</profileUri> d'avoir faire <commitsListUri>{{contributionsCount}} contribution(s)</commitsListUri> dans <repoUri>{{repo}}</repoUri>"
+    "asciidoc.random.contributor.text": "Merci <profileUri>{{login}}</profileUri> d'avoir fait <commitsListUri>{{contributionsCount}} contribution(s)</commitsListUri> dans <repoUri>{{repo}}</repoUri>"
 }


### PR DESCRIPTION
# Description of change
Fix a very small spelling mistake in French :fr: 

- [x] `npm test` passes
