### PR TITLE
Revert erroneous change to GPG blog publication date

### DIFF
--- a/content/blog/gpg-signed-releases/index.md
+++ b/content/blog/gpg-signed-releases/index.md
@@ -1,6 +1,6 @@
 ---
 title: Verifying GPG signatures for Temurin downloads
-date: "2023-09-28T18:26:15Z"
+date: "2022-07-27T16:00:00+00:00"
 author: sxa
 description: How to verify GPG signatures of the Temurin artifacts using the Eclipse public key
 tags:


### PR DESCRIPTION
https://github.com/adoptium/adoptium.net/pull/2271 changed the date on the GPG blog making it look new and appearing at the top of the blog list. This PR reverts that change.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
