### PR TITLE
Put correct jdk8u PSU version in the banner

### DIFF
--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -9,7 +9,7 @@ const Banner = () => {
    return (
      <div className="alert text-white alert-dismissible fade show mb-0 text-center" style={{ backgroundColor: '#ff1464' }} role="alert">
      <strong className='p-1'>13th October 2023:</strong>
-         We are creating the October 2023 PSU binaries for Eclipse Temurin 8u391, 11.0.21 and 17.0.9 and 21.0.1<br/>
+         We are creating the October 2023 PSU binaries for Eclipse Temurin 8u392, 11.0.21 and 17.0.9 and 21.0.1<br/>
          You can track progress <a className='alert-link p-1 text-white' href="https://github.com/adoptium/temurin/issues/6">by platform</a> 
          or <a className='alert-link p-1 text-white' href="https://github.com/adoptium/temurin/issues/5">by detailed release checklist</a>.
       <button type="button" className="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>


### PR DESCRIPTION
# Description of change

Fix to version number. Banner currently shows the CPU version, not the PSU one which we buid.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
