### PR TITLE
Update July release blog which listed incorrect AIX prereq version

### DIFF
--- a/content/blog/eclipse-temurin-8u382-11020-1708-and-2002-available/index.md
+++ b/content/blog/eclipse-temurin-8u382-11020-1708-and-2002-available/index.md
@@ -53,4 +53,4 @@ Adoptium is not releasing Temurin 20.0.2 for Linux PPC64le, s390x, arm32, and AI
 
 ### New AIX version requirement
 
-From this release onwards, all Temurin versions published for AIX now require AIX OS version 7.1.
+From this release onwards, all Temurin versions published for AIX now require AIX OS version 7.2.


### PR DESCRIPTION
# Description of change

NOTE: This glosses over the [Harfbuzz problem](https://github.com/adoptium/aqa-tests/issues/4683) that we have that's blocking some of the AIX releases at the moment :-)

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
