### PR TITLE
Adds the Linux aarch64 binary link

### DIFF
--- a/content/asciidoc-pages/jmc/index.adoc
+++ b/content/asciidoc-pages/jmc/index.adoc
@@ -41,8 +41,12 @@ https://github.com/thegreystone/jmc-tutorial[Marcus Hirt’s tutorial].
 |macOS (aarch_64) |{snapshot}-SNAPSHOT
 |https://github.com/adoptium/jmc-build/releases/download/{snapshot}-SNAPSHOT/org.openjdk.jmc-{snapshot}-SNAPSHOT-macosx.cocoa.aarch64.tar.gz[org.openjdk.jmc-{snapshot}-SNAPSHOT-macosx.cocoa.aarch_64.tar.gz]
 
-|Linux |{snapshot}-SNAPSHOT
+|Linux (x86_64)|{snapshot}-SNAPSHOT
 |https://github.com/adoptium/jmc-build/releases/download/{snapshot}-SNAPSHOT/org.openjdk.jmc-{snapshot}-SNAPSHOT-linux.gtk.x86_64.tar.gz[org.openjdk.jmc-{snapshot}-SNAPSHOT-linux.gtk.x86_64.tar.gz]
+
+|Linux (aarch64)|{snapshot}-SNAPSHOT
+|https://github.com/adoptium/jmc-build/releases/download/{snapshot}-SNAPSHOT/org.openjdk.jmc-{snapshot}-SNAPSHOT-linux.gtk.aarch64.tar.gz[org.openjdk.jmc-{snapshot}-SNAPSHOT-linux.gtk.aarch64.tar.gz]
+
 |=======================================================================
 
 == Note (MacOS X)


### PR DESCRIPTION
# Description of change
Adds the newly available Linux aarch64 artifact

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
