### PR TITLE
Extend JDK11 support date to Oct 2025 (to match OpenJDK)

### DIFF
--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -46,7 +46,7 @@ Sep 2023
 [.small]#jdk-11.0.20+8#
 | 17 Oct 2023 +
 [.small]#jdk-11.0.21#
-| At least Oct 2024
+| At least Oct 2025
 
 | Java 8 (LTS)
 | Mar 2014


### PR DESCRIPTION
Per The OpenJDK release matrix, https://www.java.com/releases/matrix/, JDK 11.0.29 is expected to be released in October of 2025

# Description of change
Updated the "End of Availability" date for JDK 11, based on dates published on the OpenJDK website.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
