### PR TITLE
update supported platforms list

### DIFF
--- a/content/asciidoc-pages/supported-platforms/index.adoc
+++ b/content/asciidoc-pages/supported-platforms/index.adoc
@@ -74,7 +74,7 @@ icon:check[] - Supported, icon:docker[] - Docker image available, icon:times[] -
 | Ubuntu 18.04 | icon:times[] footnote:nojit[] | icon:check[] | icon:check[] | icon:times[]
 
 5+h| macOS (x64) footnote:[These builds should work on macOS 10.12 or higher.]
-| macOS 13 | icon:times[] | icon:check[] | icon:check[] | icon:check[]
+| macOS 14 | icon:times[] | icon:check[] | icon:check[] | icon:check[]
 | macOS 13 | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 | macOS 12 | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 | macOS 11 | icon:check[] | icon:check[] | icon:check[] | icon:check[]

--- a/content/asciidoc-pages/supported-platforms/index.adoc
+++ b/content/asciidoc-pages/supported-platforms/index.adoc
@@ -74,12 +74,13 @@ icon:check[] - Supported, icon:docker[] - Docker image available, icon:times[] -
 | Ubuntu 18.04 | icon:times[] footnote:nojit[] | icon:check[] | icon:check[] | icon:times[]
 
 5+h| macOS (x64) footnote:[These builds should work on macOS 10.12 or higher.]
+| macOS 13 | icon:times[] | icon:check[] | icon:check[] | icon:check[]
 | macOS 13 | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 | macOS 12 | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 | macOS 11 | icon:check[] | icon:check[] | icon:check[] | icon:check[]
-| macOS 10.15 | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 
 5+h| macOS (Apple Silicon)
+| macOS 14 | icon:times[] | icon:check[] | icon:check[] | icon:check[]
 | macOS 13 | icon:times[] | icon:check[] | icon:check[] | icon:check[]
 | macOS 12 | icon:times[] | icon:check[] | icon:check[] | icon:check[]
 | macOS 11 | icon:times[] | icon:check[] | icon:check[] | icon:check[]

--- a/content/asciidoc-pages/supported-platforms/index.adoc
+++ b/content/asciidoc-pages/supported-platforms/index.adoc
@@ -35,7 +35,7 @@ icon:check[] - Supported, icon:docker[] - Docker image available, icon:times[] -
 
 5+h| Linux (x64) footnote:[These builds should work on any distribution with glibc version 2.17 or higher. Versions up to 17 will work with glibc 2.12]
 | Alpine Linux 3.5 or later (Headless) | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
-| RHEL / UBI 9.x | icon:check[] | icon:check[] | icon:check[] | icon:check[] icon:docker[]
+| RHEL / UBI 9.x | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
 | RHEL / UBI 8.x | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 | RHEL / CentOS 7.x | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[]
 | SUSE Linux Enterprise Server (SLES) 12 | icon:check[] | icon:check[] | icon:check[] | icon:check[]
@@ -45,7 +45,7 @@ icon:check[] - Supported, icon:docker[] - Docker image available, icon:times[] -
 
 5+h| Linux (ARM 64-bit) footnote:glibc217[These builds should work on any distribution with glibc version 2.17 or higher.]
 | Alpine Linux 3.5 or later (Headless) | icon:times[] | icon:times[] | icon:times[] | icon:check[] icon:docker[] 
-| RHEL / UBI 9.x | icon:check[] | icon:check[] | icon:check[] | icon:check[] icon:docker[]
+| RHEL / UBI 9.x | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
 | RHEL / UBI 8.x | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 | RHEL / CentOS 7.x | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[]
 | Ubuntu 22.04 | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
@@ -58,12 +58,12 @@ icon:check[] - Supported, icon:docker[] - Docker image available, icon:times[] -
 | Ubuntu 18.04 | icon:check[] | icon:check[] | icon:check[] | icon:times[]
 
 5+h| Linux (PowerPC 64-bit Little Endian) footnote:glibc217[]
-| RHEL / UBI 9.x | icon:check[] | icon:check[] | icon:check[] | icon:times[]
-| RHEL / UBI 8.x | icon:check[] | icon:check[] | icon:check[] | icon:times[]
-| RHEL / CentOS 7.x | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:times[]
-| Ubuntu 22.04 | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:times[]
-| Ubuntu 20.04 | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:times[]
-| Ubuntu 18.04 | icon:check[] | icon:check[] | icon:check[] | icon:times[]
+| RHEL / UBI 9.x | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
+| RHEL / UBI 8.x | icon:check[] | icon:check[] | icon:check[] | icon:check[]
+| RHEL / CentOS 7.x | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:check[] | icon:check[]
+| Ubuntu 22.04 | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
+| Ubuntu 20.04 | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
+| Ubuntu 18.04 | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 
 5+h| Linux (s390x) footnote:glibc217[]
 | RHEL / UBI 9.x | icon:times[] footnote:nojit[JDK8 on s390x has no JIT so is unsupported.] | icon:check[] | icon:check[] | icon:times[]


### PR DESCRIPTION
- We ship ppc64le images for Ubi9 and have now added ppc64le support for 21
- UBI9 docker images are available for aarch64
- macOS 14 has been released

# Description of change
<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
