### PR TITLE
[issue-2443] Update release roadmap support page

### DIFF
--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -42,11 +42,11 @@ Mar 2024
 
 | Java 17 (LTS)
 | Sep 2021
-| 27 Oct 2023 +
+| 17 Oct 2023 +
 [.small]#jdk-17.0.9+9.1#
-| 21 Jan 2024 +
-[.small]#jdk-17.0.14#
-| Sep 2029
+| 16 Jan 2024 +
+[.small]#jdk-17.0.10#
+| At least Oct 2027
 
 | Java 11 (LTS)
 | Sep 2018

--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -28,7 +28,7 @@ Mar 2024
 
 | Java 19
 | Sep 2022
-| 26 Jan 2023 +
+| 17 Jan 2023 +
 [.small]#jdk-19.0.2+7#
 | EOSL^[2]^
 | Mar 2023

--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -9,7 +9,7 @@
 [.small]#jdk-21.0.1+12#
 | 21 Jan 2024 +
 [.small]#21.0.6#
-| Expected Sep 2029
+| Sep 2031
 
 | Java 20
 | Mar 2023
@@ -38,7 +38,7 @@
 [.small]#jdk-17.0.9+9.1#
 | 21 Jan 2024 +
 [.small]#17.0.14#
-| At least Oct 2027
+| Sep 2029
 
 | Java 11 (LTS)
 | Sep 2018
@@ -46,7 +46,7 @@
 [.small]#jdk-11.0.20+8#
 | 21 Jan 2024 +
 [.small]#11.0.26#
-| At least Oct 2024
+| Sep 2026
 
 | Java 8 (LTS)
 | Mar 2014
@@ -54,6 +54,6 @@
 [.small]#jdk8u382-b05#
 | 21 Jan 2024 +
 [.small]#jdk8u441#
-| At least Nov 2026
+| Dec 2030
 
 |===

--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -8,26 +8,26 @@
 | 27 octobre 2023 +
 [.small]#jdk-21.0.1+12#
 | 21 Jan 2024 +
-[.small]#21.0.6#
+[.small]#jdk-21.0.6#
 | Sep 2031
 
 | Java 20
 | Mar 2023
-| 20 Jul 2023 +
+| 25 Jul 2023 +
 [.small]#jdk-20.0.2+9#
 | EOSL^[2]^
 | Sep 2023
 
 | Java 19
 | Sep 2022
-| 17 Jan 2023 +
+| 26 Jan 2023 +
 [.small]#jdk-19.0.2+7#
 | EOSL^[2]^
 | Mar 2023
 
 | Java 18
 | Mar 2022
-| 28 Aug 2022 +
+| 27 Aug 2022 +
 [.small]#jdk-18.0.2.1+1#
 | EOSL^[2]^
 | Sep 2022
@@ -37,21 +37,21 @@
 | 27 Oct 2023 +
 [.small]#jdk-17.0.9+9.1#
 | 21 Jan 2024 +
-[.small]#17.0.14#
+[.small]#jdk-17.0.14#
 | Sep 2029
 
 | Java 11 (LTS)
 | Sep 2018
-| 18 Jul 2023 +
-[.small]#jdk-11.0.20+8#
+| 27 Oct 2023 +
+[.small]#jdk-11.0.21+9#
 | 21 Jan 2024 +
-[.small]#11.0.26#
+[.small]#jdk-11.0.26#
 | Sep 2026
 
 | Java 8 (LTS)
 | Mar 2014
-| 21 Jul 2023 +
-[.small]#jdk8u382-b05#
+| 1 Nov 2023 +
+[.small]#jdk8u392-b08#
 | 21 Jan 2024 +
 [.small]#jdk8u441#
 | Dec 2030

--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -3,6 +3,14 @@
 
 | Java Version  | First Availability | Latest Release | Next Release Due | End of Availability ^[1]^
 
+| Java 22
+| Expected +
+Mar 2024
+| Not available
+| Expected +
+Mar 2024
+| Expected Sep 2024
+
 | Java 21 (LTS)
 | Sep 2023
 | 24 Oct 2023 +

--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -61,7 +61,7 @@ Mar 2024
 | 17 Oct 2023 +
 [.small]#jdk8u392-b08#
 | 16 Jan 2024 +
-[.small]#jdk8u401#
+[.small]#jdk8u402#
 | At least Nov 2026
 
 |===

--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -17,7 +17,7 @@ Mar 2024
 [.small]#jdk-21.0.1+12#
 | 16 Jan 2024 +
 [.small]#jdk-21.0.2#
-| At least Sep 2029
+| At least Dec 2029
 
 | Java 20
 | Mar 2023

--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -5,11 +5,11 @@
 
 | Java 21 (LTS)
 | Sep 2023
-| 27 octobre 2023 +
+| 24 Oct 2023 +
 [.small]#jdk-21.0.1+12#
-| 21 Jan 2024 +
-[.small]#jdk-21.0.6#
-| Sep 2031
+| 16 Jan 2024 +
+[.small]#jdk-21.0.2#
+| Sep 2029
 
 | Java 20
 | Mar 2023

--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -58,10 +58,10 @@ Mar 2024
 
 | Java 8 (LTS)
 | Mar 2014
-| 1 Nov 2023 +
+| 17 Oct 2023 +
 [.small]#jdk8u392-b08#
-| 21 Jan 2024 +
-[.small]#jdk8u441#
-| Dec 2030
+| 16 Jan 2024 +
+[.small]#jdk8u401#
+| At least Nov 2026
 
 |===

--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -4,11 +4,11 @@
 | Java Version  | First Availability | Latest Release | Next Release Due | End of Availability ^[1]^
 
 | Java 21 (LTS)
-| Expected +
-Sep 2023
-| Not available
-| Expected +
-Sep 2023
+| Sep 2023
+| 27 octobre 2023 +
+[.small]#jdk-21.0.1+12#
+| 21 Jan 2024 +
+[.small]#21.0.6#
 | Expected Sep 2029
 
 | Java 20
@@ -16,7 +16,7 @@ Sep 2023
 | 20 Jul 2023 +
 [.small]#jdk-20.0.2+9#
 | EOSL^[2]^
-| Expected Sep 2023
+| Sep 2023
 
 | Java 19
 | Sep 2022
@@ -34,26 +34,26 @@ Sep 2023
 
 | Java 17 (LTS)
 | Sep 2021
-| 18 Jul 2023 +
-[.small]#jdk-17.0.8+7#
-| 17 Oct 2023 +
-[.small]#jdk-17.0.9#
+| 27 Oct 2023 +
+[.small]#jdk-17.0.9+9.1#
+| 21 Jan 2024 +
+[.small]#17.0.14#
 | At least Oct 2027
 
 | Java 11 (LTS)
 | Sep 2018
 | 18 Jul 2023 +
 [.small]#jdk-11.0.20+8#
-| 17 Oct 2023 +
-[.small]#jdk-11.0.21#
+| 21 Jan 2024 +
+[.small]#11.0.26#
 | At least Oct 2024
 
 | Java 8 (LTS)
 | Mar 2014
 | 21 Jul 2023 +
 [.small]#jdk8u382-b05#
-| 17 Oct 2023 +
-[.small]#jdk8u392#
+| 21 Jan 2024 +
+[.small]#jdk8u441#
 | At least Nov 2026
 
 |===

--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -17,7 +17,7 @@ Mar 2024
 [.small]#jdk-21.0.1+12#
 | 16 Jan 2024 +
 [.small]#jdk-21.0.2#
-| Sep 2029
+| At least Sep 2029
 
 | Java 20
 | Mar 2023

--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -13,7 +13,7 @@ Mar 2024
 
 | Java 21 (LTS)
 | Sep 2023
-| 24 Oct 2023 +
+| 17 Oct 2023 +
 [.small]#jdk-21.0.1+12#
 | 16 Jan 2024 +
 [.small]#jdk-21.0.2#

--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -35,7 +35,7 @@ Mar 2024
 
 | Java 18
 | Mar 2022
-| 27 Aug 2022 +
+| 18 Aug 2022 +
 [.small]#jdk-18.0.2.1+1#
 | EOSL^[2]^
 | Sep 2022

--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -21,7 +21,7 @@ Mar 2024
 
 | Java 20
 | Mar 2023
-| 25 Jul 2023 +
+| 18 Jul 2023 +
 [.small]#jdk-20.0.2+9#
 | EOSL^[2]^
 | Sep 2023

--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -50,11 +50,11 @@ Mar 2024
 
 | Java 11 (LTS)
 | Sep 2018
-| 27 Oct 2023 +
+| 17 Oct 2023 +
 [.small]#jdk-11.0.21+9#
-| 21 Jan 2024 +
-[.small]#jdk-11.0.26#
-| Sep 2026
+| 16 Jan 2024 +
+[.small]#jdk-11.0.22#
+| At least Oct 2024
 
 | Java 8 (LTS)
 | Mar 2014


### PR DESCRIPTION
# Description of change
This PR aims to fix the issue adoptium/adoptium.net-redesign#1127 


I have updated End Of Support Life (EOSL) from https://www.java.com/releases/


## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
