### PR TITLE
Remove checklist link from release banner template

### DIFF
--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -10,8 +10,7 @@ const Banner = () => {
   //    <div className="alert text-white alert-dismissible fade show mb-0 text-center" style={{ backgroundColor: '#ff1464' }} role="alert">
   //    <strong className='p-1'>13th October 2023:</strong>
   //        We are creating the October 2023 PSU binaries for Eclipse Temurin 8u392, 11.0.21 and 17.0.9 and 21.0.1<br/>
-  //        You can track progress <a className='alert-link p-1 text-white' href="https://github.com/adoptium/temurin/issues/6">by platform</a> 
-  //        or <a className='alert-link p-1 text-white' href="https://github.com/adoptium/temurin/issues/5">by detailed release checklist</a>.
+  //        You can track progress <a className='alert-link p-1 text-white' href="https://github.com/adoptium/temurin/issues/6">by platform</a>.
   //     <button type="button" className="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
   //    </div>
   //  );


### PR DESCRIPTION
As discussed in retrospective, we should not include the checklist in the template, so I'm adjusting the commented out section that included it for the October release to discourage it from being added

Ref: https://github.com/adoptium/temurin/issues/4#issuecomment-1766668066

# Description of change
<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
