### PR TITLE
Extend Temurin 11 support date

### DIFF
--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -54,7 +54,7 @@ Mar 2024
 [.small]#jdk-11.0.21+9#
 | 16 Jan 2024 +
 [.small]#jdk-11.0.22#
-| At least Oct 2024
+| At least Oct 2027
 
 | Java 8 (LTS)
 | Mar 2014


### PR DESCRIPTION
# Description of change

Based upon discussions with OpenJDK 11u project lead, we can update the Temurin 11 updates to Oct 2027. This will cover, **at a minimum**, critical impact security fixes and selected urgent-priority bug fixes, if and when available through OpenJDK.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)

Closes #2377 