### PR TITLE
Correct way to add GPG key

### DIFF
--- a/content/asciidoc-pages/installation/linux/index.adoc
+++ b/content/asciidoc-pages/installation/linux/index.adoc
@@ -43,15 +43,14 @@ apt install -y wget apt-transport-https
 +
 [source, bash]
 ----
-mkdir -p /etc/apt/keyrings
-wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc
+wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/adoptium.gpg > /dev/null
 ----
 +
 . Configure the Eclipse Adoptium apt repository. To check the full list of versions supported take a look at the list in the tree at https://packages.adoptium.net/ui/native/deb/dists/.
 +
 [source, bash]
 ----
-echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
+echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
 ----
 TIP: For Linux Mint (based on Ubuntu) you have to replace `VERSION_CODENAME` with `UBUNTU_CODENAME`.
 +


### PR DESCRIPTION
using /etc/apt/keyrings is deprecated, see https://manpages.debian.org/testing/apt/apt-key.8.en.html

# Description of change
<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

Updated the documentation on how to add gpg key and install on debian/ubuntu distros.
Using /etc/apt/keyrings is deprecated, see https://manpages.debian.org/testing/apt/apt-key.8.en.html

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] documentation is changed or added (if applicable)
- [X] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
