### PR TITLE
Downgrade vitest-canvas-mock version to avoid jest-canvas-mock versio…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
         "html-to-text": "^9.0.5",
         "i18next": "^23.7.11",
         "iso-639-1": "^3.1.0",
-        "jest-canvas-mock": "2.5.1",
         "moment": "^2.30.1",
         "prismjs": "^1.29.0",
         "prop-types": "^15.8.1",
@@ -88,11 +87,12 @@
         "axios-mock-adapter": "^1.22.0",
         "babel-preset-gatsby": "^3.12.1",
         "gatsby-cli": "^5.12.4",
+        "jest-canvas-mock": "2.5.1",
         "jsdom": "^22.1.0",
         "prettier": "3.1.1",
         "vitest": "^1.0.4",
         "vitest-axe": "^1.0.0-pre.3",
-        "vitest-canvas-mock": "^0.3.3"
+        "vitest-canvas-mock": "0.3.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -10059,7 +10059,8 @@
     "node_modules/cssfontparser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
-      "integrity": "sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg=="
+      "integrity": "sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==",
+      "dev": true
     },
     "node_modules/cssnano": {
       "version": "5.1.15",
@@ -16058,9 +16059,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "23.7.13",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.7.13.tgz",
-      "integrity": "sha512-DbCPlw6VmURSZa43iOnycxq9o15e+WuBWDBZ3aj+gQZcDz4sgnuKwrcwmP1n8gSSCwCN7CRFGTpnwTd93A16Mg==",
+      "version": "23.7.14",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.7.14.tgz",
+      "integrity": "sha512-URAhZ3zvqQOIiKUDUyv/f5sCSS0+QnFaEPS0qGSTea0p4tQ1kgddeR3/dUZDoyoqf3zSRQCPZAgLs/+LFKj8yw==",
       "funding": [
         {
           "type": "individual",
@@ -17255,6 +17256,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.5.1.tgz",
       "integrity": "sha512-IVnRiz+v4EYn3ydM/pBo8GW/J+nU/Hg5gHBQQOUQhdRyNfvHnabB8ReqARLO0p+kvQghqr4V0tA92CF3JcUSRg==",
+      "dev": true,
       "dependencies": {
         "cssfontparser": "^1.2.1",
         "moo-color": "^1.0.2"
@@ -20707,6 +20709,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
       "integrity": "sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "^1.1.4"
       }
@@ -20714,7 +20717,8 @@
     "node_modules/moo-color/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/move-file": {
       "version": "3.1.0",
@@ -24015,9 +24019,9 @@
       }
     },
     "node_modules/regex-parser": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.11.tgz",
-      "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.3.0.tgz",
+      "integrity": "sha512-TVILVSz2jY5D47F4mA4MppkBrafEaiUWJO/TcZHEIuI13AqoZMkK1WMA4Om1YkYbTx+9Ki1/tSUXbceyr9saRg=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.1",
@@ -28344,21 +28348,21 @@
       }
     },
     "node_modules/vitest-canvas-mock": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/vitest-canvas-mock/-/vitest-canvas-mock-0.3.3.tgz",
-      "integrity": "sha512-3P968tYBpqYyzzOaVtqnmYjqbe13576/fkjbDEJSfQAkHtC5/UjuRHOhFEN/ZV5HVZIkaROBUWgazDKJ+Ibw+Q==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/vitest-canvas-mock/-/vitest-canvas-mock-0.3.2.tgz",
+      "integrity": "sha512-lds7MKxvFFPDCGLXsQI2ym1fxvC93DaS0Bb6sdjvylFyL6NYrAAcPb6xZGF2sMOt5fSLHddqAQaujqpbc3p0Zg==",
       "dev": true,
       "dependencies": {
-        "jest-canvas-mock": "~2.5.2"
+        "jest-canvas-mock": "~2.4.0"
       },
       "peerDependencies": {
         "vitest": "*"
       }
     },
     "node_modules/vitest-canvas-mock/node_modules/jest-canvas-mock": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.5.2.tgz",
-      "integrity": "sha512-vgnpPupjOL6+L5oJXzxTxFrlGEIbHdZqFU+LFNdtLxZ3lRDCl17FlTMM7IatoRQkrcyOTMlDinjUguqmQ6bR2A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.4.0.tgz",
+      "integrity": "sha512-mmMpZzpmLzn5vepIaHk5HoH3Ka4WykbSoLuG/EKoJd0x0ID/t+INo1l8ByfcUJuDM+RIsL4QDg/gDnBbrj2/IQ==",
       "dev": true,
       "dependencies": {
         "cssfontparser": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "html-to-text": "^9.0.5",
     "i18next": "^23.7.11",
     "iso-639-1": "^3.1.0",
-    "jest-canvas-mock": "2.5.1",
     "moment": "^2.30.1",
     "prismjs": "^1.29.0",
     "prop-types": "^15.8.1",
@@ -88,7 +87,8 @@
     "prettier": "3.1.1",
     "vitest": "^1.0.4",
     "vitest-axe": "^1.0.0-pre.3",
-    "vitest-canvas-mock": "^0.3.3"
+    "vitest-canvas-mock": "0.3.2",
+    "jest-canvas-mock": "2.5.1"
   },
   "overrides": {
     "gatsby-plugin-react-i18next": {


### PR DESCRIPTION
Downgrade vitest-canvas-mock version to avoid jest-canvas-mock version 2.5.2 causing trouble in CI (npm run coverage)


## Checklist
- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
