### PR TITLE
add gpg to the apt list for Ubuntu/Debian installers

### DIFF
--- a/content/asciidoc-pages/installation/linux/index.adoc
+++ b/content/asciidoc-pages/installation/linux/index.adoc
@@ -36,7 +36,7 @@ e.g temurin-17-jdk or temurin-8-jdk
 +
 [source, bash]
 ----
-apt install -y wget apt-transport-https
+apt install -y wget apt-transport-https gpg
 ----
 +
 . Download the Eclipse Adoptium GPG key:


### PR DESCRIPTION
# Description of change

gpg is required on the "Download the Eclipse Adoptium GPG key:" step but is not included in the command that talks about the prerequisite packages that are required.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
