### PR TITLE
Add translations of nightly-builds and downloads in French

### DIFF
--- a/locales/fr/download.json
+++ b/locales/fr/download.json
@@ -14,5 +14,14 @@
   "Source Code Archive": "Code source",
   "Any": "Tout",
   "Installation guide": "Guide d'installation",
-  "Source Code": "Code source"
+  "Source Code": "Code source",
+  "archive.do.not.use.unsupported": "L’utilisation de versions anciennes, modifiées ou non prises en charge n’est pas recommandée.",
+  "archive.be.aware": "Veuillez noter que cette page contient d'anciennes versions d'Eclipse Temurin conservées à titre de référence. Les <latestReleasesLink>dernières versions</latestReleasesLink> doivent être utilisées pour le développement et la production.",
+  "download.not.available": "Non disponible",
+  "nightly.builds.unsupported.in.production": "Ces versions ne sont pas prises en charge et ne sont pas destinées à être utilisées en production.",
+  "vendor.selector.view": "Voir",
+  "vendor.selector.prior.to": "nightly builds avant le :",
+  "nightly.builds.be.aware": "Veuillez noter que cette archive contient des versions intermédiaires créées comme étape de développement vers une <fullReleaseLink>version officielle</fullReleaseLink>. Les builds intermédiaires sont éphémères et peuvent disparaître dans le futur.",
+  "nightly.builds.notice.title": "La note suivante s'applique aux versions intermédiaires :",
+  "nightly.builds.quoted.notice": "Il s'agit d'une version intermédiaire mise à disposition à des fins de test uniquement. Le code n'est pas testé et présumé incompatible avec la spécification Java SE. Vous ne devez pas déployer ou écrire dans ce code, mais plutôt utiliser la version testée et certifiée compatible Java SE du code. La redistribution de cette version doit conserver cet avis."
 }

--- a/locales/fr/temurin.json
+++ b/locales/fr/temurin.json
@@ -1,6 +1,7 @@
 {
   "release.intro": "Eclipse Temurin est le projet open source Java SE basé sur OpenJDK. Temurin est disponible pour une <supportedPlatformsLink>large gamme de plates-formes</supportedPlatformsLink> et de versions de Java SE. Les dernières versions recommandées pour une utilisation en production sont répertoriées ci-dessous et sont régulièrement <supportLink>mises à jour et prises en charge</supportLink> par la communauté Adoptium. L'aide à la migration, les images de conteneurs et les guides d'installation des packages sont disponibles dans la <docsLink>section documentation</docsLink>.",
-  "Use the drop-down boxes below to filter the list of current releases.": "Utilisez la liste déroulante ci-dessous pour voir les versions actuelles.",
+  "Use the drop-down boxes below to filter the list of current releases.": "Utilisez les listes déroulantes ci-dessous pour filtrer les versions.",
+  "Use the drop-down boxes below to filter the list of releases.": "Utilisez les listes déroulantes ci-dessous pour filtrer les versions.",
   "Previous releases are available in the Temurin archive.": "Les versions précédentes sont disponibles dans les archives Temurin.",
   "Release Notes": "Notes de version",
   "Installation Guide": "Guide d'installation",

--- a/src/components/TemurinArchiveTable/__tests__/__snapshots__/TemurinArchiveTable.test.tsx.snap
+++ b/src/components/TemurinArchiveTable/__tests__/__snapshots__/TemurinArchiveTable.test.tsx.snap
@@ -189,7 +189,7 @@ exports[`TemurinArchiveTable component > renders correctly 1`] = `
                       class="btn"
                       style="width: 9em; background-color: rgb(215, 222, 233);"
                     >
-                      Not Available
+                      Text
                     </a>
                   </td>
                   <td

--- a/src/components/TemurinArchiveTable/index.tsx
+++ b/src/components/TemurinArchiveTable/index.tsx
@@ -83,7 +83,7 @@ const TemurinArchiveTable = ({results, updatePage}) => {
                                                                                     />
                                                                                 ) :
                                                                                     <a className="btn" style={{width: "9em", backgroundColor: "#D7DEE9"}}>
-                                                                                        Not Available
+                                                                                        <Trans i18nKey='download.not.available' default='Not Available' />
                                                                                     </a>
                                                                                 }
                                                                             </td>

--- a/src/components/TemurinArchiveTable/index.tsx
+++ b/src/components/TemurinArchiveTable/index.tsx
@@ -83,7 +83,7 @@ const TemurinArchiveTable = ({results, updatePage}) => {
                                                                                     />
                                                                                 ) :
                                                                                     <a className="btn" style={{width: "9em", backgroundColor: "#D7DEE9"}}>
-                                                                                        <Trans i18nKey='download.not.available' default='Not Available' />
+                                                                                        <Trans i18nKey='download.not.available' defaults='Not Available' />
                                                                                     </a>
                                                                                 }
                                                                             </td>

--- a/src/components/TemurinNightlyTable/__tests__/__snapshots__/TemurinNightlyTable.test.tsx.snap
+++ b/src/components/TemurinNightlyTable/__tests__/__snapshots__/TemurinNightlyTable.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`TemurinNightlyTable component > renders correctly 1`] = `
             </a>
           </td>
           <td>
-            Not Available
+            Text
           </td>
           <td>
             <a

--- a/src/components/TemurinNightlyTable/index.tsx
+++ b/src/components/TemurinNightlyTable/index.tsx
@@ -37,7 +37,7 @@ const TemurinNightlyTable = ({results}) => {
                                                             {asset.installer_link ? (
                                                                 <td><Link to="/download" state={{ link: asset.installer_link, checksum: asset.installer_checksum }}>{asset.installer_extension}</Link></td>
                                                             ) :
-                                                                <td>Not Available</td>
+                                                                <td><Trans i18nKey='download.not.available' default='Not Available' /></td>
                                                             }
                                                             <td><a href="" data-bs-toggle="modal" data-bs-target="#checksumModal" data-bs-checksum={asset.checksum}><Trans>Checksum</Trans></a></td>
                                                         </tr>

--- a/src/components/TemurinNightlyTable/index.tsx
+++ b/src/components/TemurinNightlyTable/index.tsx
@@ -37,7 +37,7 @@ const TemurinNightlyTable = ({results}) => {
                                                             {asset.installer_link ? (
                                                                 <td><Link to="/download" state={{ link: asset.installer_link, checksum: asset.installer_checksum }}>{asset.installer_extension}</Link></td>
                                                             ) :
-                                                                <td><Trans i18nKey='download.not.available' default='Not Available' /></td>
+                                                                <td><Trans i18nKey='download.not.available' defaults='Not Available' /></td>
                                                             }
                                                             <td><a href="" data-bs-toggle="modal" data-bs-target="#checksumModal" data-bs-checksum={asset.checksum}><Trans>Checksum</Trans></a></td>
                                                         </tr>

--- a/src/components/VersionSelector/__tests__/__snapshots__/VersionSelector.test.tsx.snap
+++ b/src/components/VersionSelector/__tests__/__snapshots__/VersionSelector.test.tsx.snap
@@ -38,12 +38,11 @@ exports[`VersionSelector > updates the number of builds and build date when the 
   [36m</div>[39m
   [36m<div[39m
     [33mclass[39m=[32m"input-group pb-5 d-flex justify-content-center"[39m
+    [33mstyle[39m=[32m"line-height: 36px;"[39m
   [36m>[39m
     [36m<span[39m
       [33mclass[39m=[32m"p-2"[39m
-    [36m>[39m
-      [0mView[0m
-    [36m</span>[39m
+    [36m/>[39m
     [36m<select[39m
       [33maria-label[39m=[32m"Filter by number of builds"[39m
       [33mclass[39m=[32m"form-select form-select-sm"[39m
@@ -80,9 +79,7 @@ exports[`VersionSelector > updates the number of builds and build date when the 
     [36m</select>[39m
     [36m<span[39m
       [33mclass[39m=[32m"p-2"[39m
-    [36m>[39m
-      [0mnightly builds prior to:[0m
-    [36m</span>[39m
+    [36m/>[39m
     [36m<div[39m
       [33mclass[39m=[32m"MuiFormControl-root MuiTextField-root css-qixv09-MuiFormControl-root-MuiTextField-root"[39m
     [36m>[39m

--- a/src/components/VersionSelector/index.tsx
+++ b/src/components/VersionSelector/index.tsx
@@ -99,7 +99,7 @@ const VersionSelector = ({updater, releaseType, Table}) => {
       </div>
       {releaseType === "ea" && (
         <div className="input-group pb-5 d-flex justify-content-center" style={{lineHeight: '36px'}}>
-          <span className='p-2'><Trans i18nKey='vendor.selector.view' default='View'/></span>
+          <span className='p-2'><Trans i18nKey='vendor.selector.view' defaults='View'/></span>
           <select data-testid="build-num-filter" aria-label="Filter by number of builds" id="build-num-filter" onChange={(e) => setNumBuilds(e.target.value)} defaultValue={numBuilds} className="form-select form-select-sm" style={{ maxWidth: '5em' }}>
             <option key={1} value={1}>1</option>
             <option key={5} value={5}>5</option>
@@ -107,7 +107,7 @@ const VersionSelector = ({updater, releaseType, Table}) => {
             <option key={20} value={20}>20</option>
             <option key={50} value={50}>50</option>
           </select>
-          <span className='p-2'><Trans i18nKey='vendor.selector.prior.to' default='nightly builds prior to:'/></span>
+          <span className='p-2'><Trans i18nKey='vendor.selector.prior.to' defaults='nightly builds prior to:'/></span>
           <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={locale}>
             <DesktopDatePicker
               label="Build Date"

--- a/src/components/VersionSelector/index.tsx
+++ b/src/components/VersionSelector/index.tsx
@@ -98,8 +98,8 @@ const VersionSelector = ({updater, releaseType, Table}) => {
         </select>
       </div>
       {releaseType === "ea" && (
-        <div className="input-group pb-5 d-flex justify-content-center">
-          <span className='p-2'>View</span>
+        <div className="input-group pb-5 d-flex justify-content-center" style={{lineHeight: '36px'}}>
+          <span className='p-2'><Trans i18nKey='vendor.selector.view' default='View'/></span>
           <select data-testid="build-num-filter" aria-label="Filter by number of builds" id="build-num-filter" onChange={(e) => setNumBuilds(e.target.value)} defaultValue={numBuilds} className="form-select form-select-sm" style={{ maxWidth: '5em' }}>
             <option key={1} value={1}>1</option>
             <option key={5} value={5}>5</option>
@@ -107,7 +107,7 @@ const VersionSelector = ({updater, releaseType, Table}) => {
             <option key={20} value={20}>20</option>
             <option key={50} value={50}>50</option>
           </select>
-          <span className='p-2'>nightly builds prior to:</span>
+          <span className='p-2'><Trans i18nKey='vendor.selector.prior.to' default='nightly builds prior to:'/></span>
           <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={locale}>
             <DesktopDatePicker
               label="Build Date"

--- a/src/pages/temurin/__tests__/__snapshots__/archive.test.tsx.snap
+++ b/src/pages/temurin/__tests__/__snapshots__/archive.test.tsx.snap
@@ -22,19 +22,13 @@ exports[`Temurin Archive page > renders correctly 1`] = `
           <div
             class="callout callout-default text-start"
           >
-            Please be aware that this archive contains old releases of Eclipse Temurin kept for reference. The 
-            <a
-              href="/temurin/releases"
-            >
-              latest releases
-            </a>
-             should be used in development and production.
+            Text
             <br />
             <br />
             <p
               class="text-warning"
             >
-              Using old, superseded, or otherwise unsupported builds is not recommended.
+              Text
             </p>
           </div>
           <div

--- a/src/pages/temurin/__tests__/__snapshots__/nightly.test.tsx.snap
+++ b/src/pages/temurin/__tests__/__snapshots__/nightly.test.tsx.snap
@@ -22,24 +22,20 @@ exports[`Temurin Nightly page > renders correctly 1`] = `
           <div
             class="callout callout-default text-start"
           >
-            Please be aware that this archive contains intermediate builds created as a development step towards a 
-            <a
-              href="/temurin/releases"
-            >
-              full release
-            </a>
-            . Intermediate builds are ephemeral, and may disappear in the future.
+            Text
             <br />
             <br />
-            The following notice applies to intermediate builds:
+            Text
             <br />
-            “This is an intermediate build made available for testing purposes only. The code is untested and presumed incompatible with the Java SE specification. You should not deploy or write to this code, but instead use the tested and certified Java SE compatible version of the code. Redistribution of this build must retain this notice.”
+            “
+            Text
+            ”
             <br />
             <br />
             <p
               class="text-warning"
             >
-              These builds are unsupported and not for use in production.
+              Text
             </p>
           </div>
           <div
@@ -129,11 +125,12 @@ exports[`Temurin Nightly page > renders correctly 1`] = `
     </div>
     <div
       class="input-group pb-5 d-flex justify-content-center"
+      style="line-height: 36px;"
     >
       <span
         class="p-2"
       >
-        View
+        Text
       </span>
       <select
         aria-label="Filter by number of builds"
@@ -172,7 +169,7 @@ exports[`Temurin Nightly page > renders correctly 1`] = `
       <span
         class="p-2"
       >
-        nightly builds prior to:
+        Text
       </span>
       <div
         class="MuiFormControl-root MuiTextField-root css-qixv09-MuiFormControl-root-MuiTextField-root"

--- a/src/pages/temurin/archive.tsx
+++ b/src/pages/temurin/archive.tsx
@@ -9,6 +9,7 @@ import VersionSelector from '../../components/VersionSelector'
 import ChecksumModal from '../../components/ChecksumModal'
 import TemurinArchiveTable from '../../components/TemurinArchiveTable'
 import { getAssetsForVersion } from '../../hooks'
+import LinkText from '../../components/LinkText'
 
 const TemurinReleases = () => (
   <Layout>
@@ -18,10 +19,14 @@ const TemurinReleases = () => (
           <h1 className='fw-light'>Archive</h1>
           <div className='row align-items-center pt-2'>
             <div className='callout callout-default text-start'>
-              Please be aware that this archive contains old releases of Eclipse Temurin kept for reference. The <Link to='/temurin/releases'>latest releases</Link> should be used in development and production.
+              <Trans i18nKey='archive.be.aware' defaults="Please be aware that this archive contains old releases of Eclipse Temurin kept for reference. The <latestReleasesLink>latest releases</latestReleasesLink> should be used in development and production."
+                  components={{
+                    latestReleasesLink: <LinkText href='/temurin/releases' />
+                  }}
+              />
               <br />
               <br />
-              <p className='text-warning'>Using old, superseded, or otherwise unsupported builds is not recommended.</p>
+              <p className='text-warning'><Trans i18nKey='archive.do.not.use.unsupported' defaults="Using old, superseded, or otherwise unsupported builds is not recommended." /></p>
             </div>
             <div className='btn-group'>
               <Link to='/temurin/releases' className='btn btn-primary m-3'>

--- a/src/pages/temurin/nightly.tsx
+++ b/src/pages/temurin/nightly.tsx
@@ -9,6 +9,7 @@ import VersionSelector from '../../components/VersionSelector'
 import ChecksumModal from '../../components/ChecksumModal'
 import TemurinNightlyTable from '../../components/TemurinNightlyTable'
 import { getAssetsForVersion } from '../../hooks'
+import LinkText from '../../components/LinkText'
 
 const TemurinReleases = () => (
   <Layout>
@@ -18,17 +19,22 @@ const TemurinReleases = () => (
           <h1 className='fw-light'>Nightly builds</h1>
           <div className='row align-items-center pt-2'>
             <div className='callout callout-default text-start'>
-              Please be aware that this archive contains intermediate builds created as a development step towards a <Link to='/temurin/releases'>full release</Link>. Intermediate builds are ephemeral, and may disappear in the future.
+              <Trans i18nKey='nightly.builds.be.aware' default='Please be aware that this archive contains intermediate builds created as a development step towards a <fullReleaseLink>full release</fullReleaseLink>. Intermediate builds are ephemeral, and may disappear in the future.' 
+                components= {{
+                  fullReleaseLink: <LinkText href='/temurin/releases' />
+                }}
+              />
               <br />
               <br />
-              The following notice applies to intermediate builds:
+              <Trans i18nKey='nightly.builds.notice.title' default='The following notice applies to intermediate builds:' />
               <br />
-              &ldquo;This is an intermediate build made available for testing purposes only. The code is untested and presumed incompatible with the Java SE specification.
+              &ldquo;<Trans i18nKey='nightly.builds.quoted.notice' default='This is an intermediate build made available for testing purposes only. The code is untested and presumed incompatible with the Java SE specification.
               You should not deploy or write to this code, but instead use the tested and certified Java SE compatible version of the code.
-              Redistribution of this build must retain this notice.&rdquo;
+              Redistribution of this build must retain this notice.' />&rdquo;
               <br />
               <br />
-              <p className='text-warning'>These builds are unsupported and not for use in production.</p>
+              <p className='text-warning'>
+                <Trans i18nKey='nightly.builds.unsupported.in.production' default='These builds are unsupported and not for use in production.' /></p>
             </div>
             <div className='btn-group'>
               <Link to='/temurin/releases' className='btn btn-primary m-3'>

--- a/src/pages/temurin/nightly.tsx
+++ b/src/pages/temurin/nightly.tsx
@@ -19,22 +19,22 @@ const TemurinReleases = () => (
           <h1 className='fw-light'>Nightly builds</h1>
           <div className='row align-items-center pt-2'>
             <div className='callout callout-default text-start'>
-              <Trans i18nKey='nightly.builds.be.aware' default='Please be aware that this archive contains intermediate builds created as a development step towards a <fullReleaseLink>full release</fullReleaseLink>. Intermediate builds are ephemeral, and may disappear in the future.' 
+              <Trans i18nKey='nightly.builds.be.aware' defaults='Please be aware that this archive contains intermediate builds created as a development step towards a <fullReleaseLink>full release</fullReleaseLink>. Intermediate builds are ephemeral, and may disappear in the future.' 
                 components= {{
                   fullReleaseLink: <LinkText href='/temurin/releases' />
                 }}
               />
               <br />
               <br />
-              <Trans i18nKey='nightly.builds.notice.title' default='The following notice applies to intermediate builds:' />
+              <Trans i18nKey='nightly.builds.notice.title' defaults='The following notice applies to intermediate builds:' />
               <br />
-              &ldquo;<Trans i18nKey='nightly.builds.quoted.notice' default='This is an intermediate build made available for testing purposes only. The code is untested and presumed incompatible with the Java SE specification.
+              &ldquo;<Trans i18nKey='nightly.builds.quoted.notice' defaults='This is an intermediate build made available for testing purposes only. The code is untested and presumed incompatible with the Java SE specification.
               You should not deploy or write to this code, but instead use the tested and certified Java SE compatible version of the code.
               Redistribution of this build must retain this notice.' />&rdquo;
               <br />
               <br />
               <p className='text-warning'>
-                <Trans i18nKey='nightly.builds.unsupported.in.production' default='These builds are unsupported and not for use in production.' /></p>
+                <Trans i18nKey='nightly.builds.unsupported.in.production' defaults='These builds are unsupported and not for use in production.' /></p>
             </div>
             <div className='btn-group'>
               <Link to='/temurin/releases' className='btn btn-primary m-3'>

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -149,3 +149,6 @@ const IntersectionObserverMock = vi.fn(() => ({
 }))
 
 vi.stubGlobal('IntersectionObserver', IntersectionObserverMock)
+
+vi.stubGlobal("jest", vi);
+


### PR DESCRIPTION
# Description of change
Add translations support in nightly-builds and downloads, and add French for this parts :fr: 


## Checklist
- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
