### PR TITLE
blog: early access builds for all releases

### DIFF
--- a/content/blog/early-access-builds-feb2024/index.md
+++ b/content/blog/early-access-builds-feb2024/index.md
@@ -1,0 +1,119 @@
+---
+title: Tagged early access builds for all releases
+date: "2024-02-21T14:00:00+00:00"
+author: sxa
+description: Adoptium are now publishing early access "tagged" builds for all Temurin releases
+tags:
+  - temurin
+---
+
+[A few months ago](https://adoptium.net/blog/2023/08/early-access-builds)
+we switched from producing semi-nightly builds of the head of our
+repositories to building from upstream tags for JDK21+.  We have now
+switched all of the currently supported repositories over to the same
+mechanism so jdk8u, jdk11u, and jdk17u are also now building and publishing
+from the upstream early access tags.  This will also include our
+“evaluation” platforms - currently Windows on 64-bit Arm and Linux on
+riscv64.
+
+## How often do new tags come out?
+
+The tags are typically created upstream once a week so you should expect
+that our early access builds will be triggered and published on that
+cadence.  We are running our full set of tests on each build too, although
+unlike our formal GA releases we will not tie the publishing of these to the
+results of the test runs - early access builds should be considered untested
+and not for production use.  The early access builds will typically come out
+towards the end of each week and for those of you in the adoptium
+slack/matrix channels there are daily status posts regarding the health of
+these builds.
+
+By building and providing these early access builds from tags instead of the
+head of the default branch we can more easily work with the upstream openjdk
+project to identify the contents of a specific builds when providing but
+reports and reproduductions.
+
+## How do I get the early access builds?
+
+You can download the tagged early access builds from [the
+website](https://adoptium.net/temurin/nightly/) or the API
+using a URL such as the following, changing the operating system and
+architecture for your needs.  Note that if you are accessing these URLs
+using curl you will need to add the -L option to dereference the API’s
+redirects:
+
+- https://api.adoptium.net/v3/binary/latest/21/ea/linux/aarch64/jdk/hotspot/normal/adoptium
+
+At the time of writing this will provide you with jdk-21.0.3+3.  If you want
+a previous build to compare with then you can specify a particular version
+directly when calling them API, for example this will retrieve jdk-21.0.3+2
+from the previous week:
+
+- https://api.adoptium.net/v3/binary/version/jdk-21.0.3+2-ea-beta/linux/aarch64/jdk/hotspot/normal/adoptium
+
+Also while it is not the recommended way to retrieve them you can also find
+the releases named with an ea-beta suffix directly on the github releases
+pages such as
+
+- https://github.com/adoptium/temurin21-binaries/releases?q=ea-beta&expanded=true
+
+the release names in there correspond with the part of the API URL after
+“/version/” in the API example above.
+
+Please note that early access builds are not made available as rpm/deb or
+container images.
+
+## Can I tell what's changed in each tagged build from the previous one?
+
+Yes you can!  Since the tags are generally produced on a weekly cadence
+there typically aren't too many commits between the releases, so if you
+detect a problem there will only be a small number of commits that may have
+caused it.  A query such as this:
+
+- https://github.com/adoptium/jdk21u/compare/jdk-21.0.3+2_adopt...jdk-21.0.3+3_adopt
+
+will show the commits between 21.0.3+2 and 21.0.3+3.  Since our source is as
+clean as possible from upstream openjdk, the following URL using the
+upstream openjdk repository will typically give the same output:
+
+- https://github.com/openjdk/jdk21u/compare/jdk-21.0.3+2...jdk-21.0.3+3
+
+From the command line if you have a clone of our repository you can use
+these comments to get the list of commits and or the full source code diff:
+
+```
+git log jdk-21.0.3+2_adopt..jdk-21.0.3+3_adopt
+git diff jdk-21.0.3+2_adopt..jdk-21.0.3+3_adopt
+```
+
+## Release Candidate builds
+
+Since we are now producing builds explicitly from the tags, this means that
+when a build is declared as a release candidate for an upcoming release, you
+can download a Temurin early access build corresponding to that version on
+each of our platforms.  At the time of writing jdk-22+36 has been declared
+release candidate 1 for the upcoming JDK22 release so using similar queries
+to those referenced earlier it can be downloaded from:
+
+- https://api.adoptium.net/v3/binary/version/jdk-22+36-ea-beta/linux/aarch64/jdk/hotspot/normal/adoptium
+
+## Why am I not seeing early access builds for the latest release?
+
+There is one caveat for early access builds is that for the few months after
+a new major release comes out when it is typically managed by Oracle there
+are no regular tags produced so we cannot use the processes described in
+this article to build from tags.  In this case we will revert to building
+regularly from the head of the repository.  In these cases if you need to
+know what is in each version you can determine which github SHA we built
+from using corresponding SBoM that can be downloaded from the API by
+replacing “/jdk/” with “/sbom/” in the above URL.  For example:
+
+- https://api.adoptium.net/v3/binary/version/jdk-22+36-ea-beta/linux/aarch64/sbom/hotspot/normal/eclipse?project=jdk
+
+If you are using a GNU grep then this will easily show the commit:
+
+- `curl -L https://api.adoptium.net/v3/binary/version/jdk-22+36-ea-beta/linux/aarch64/sbom/hotspot/normal/eclipse?project=jdk | grep -A1 "OpenJDK Source Commit"`
+
+For more information on the adoptium API see the swagger-ui docs linked at https://api.adoptium.net
+
+Please let us know if you find the early access builds useful.

--- a/content/blog/early-access-builds-feb2024/index.md
+++ b/content/blog/early-access-builds-feb2024/index.md
@@ -99,16 +99,17 @@ using similar queries to those referenced earlier it can be downloaded from:
 
 ## Why am I not seeing early access builds for the latest release?
 
-There is one caveat for producing early access builds using this procedure.
+There is one caveat for producing early access builds using this procedure. 
 The process relies on the party maintaining the upstream version to perform
 the tagging in public.  If those tags aren't visible in public, we have no
 way to build from an invisible tag.  This usually happens for the time
 period when new major JDK versions get released and subsequent quarterly
-security updates for those releases are being handled by Oracle.  For
-example between JDK `22` GA, `22.0.1` and `22.0.2` releases.  There are no
-public tags available for early access tags `jdk-22.0.1+1`, `jdk-22.0.1+2`
-and so on.  Should processes change some time in the future we'd of course
-provide early access builds using the same process as for other releases.
+security updates for those releases are being handled (usually by Oracle). 
+For example between JDK `22` GA, `22.0.1` and `22.0.2` releases.  There are
+no public tags available for early access tags `jdk-22.0.1+1`,
+`jdk-22.0.1+2` and so on.  Should processes change some time in the future
+we'd of course provide early access builds using the same process as for
+other releases.
 
 In the case of no publicly visible tags, however, we will revert to building
 regularly from the head of the repository.  In these cases if you need to

--- a/content/blog/early-access-builds-feb2024/index.md
+++ b/content/blog/early-access-builds-feb2024/index.md
@@ -35,8 +35,8 @@ reports and reproductions.
 
 ## How do I get the early access builds?
 
-You can download the tagged early access builds from [the
-website](https://adoptium.net/temurin/nightly/) or the API
+You can obtain the tagged early access builds from [the
+download page](https://adoptium.net/temurin/nightly/) or the API
 using a URL such as the following, changing the operating system and
 architecture for your needs.  Note that if you are accessing these URLs
 using curl you will need to add the -L option to dereference the API’s
@@ -52,7 +52,7 @@ from the previous week:
 - https://api.adoptium.net/v3/binary/version/jdk-21.0.3+2-ea-beta/linux/aarch64/jdk/hotspot/normal/adoptium
 
 Also while it is not the recommended way to retrieve them you can also find
-the releases named with an ea-beta suffix directly on the github releases
+the releases named with an ea-beta suffix directly on the GitHub releases
 pages such as
 
 - https://github.com/adoptium/temurin21-binaries/releases?q=ea-beta&expanded=true
@@ -78,10 +78,10 @@ upstream openjdk repository will typically give the same output:
 
 - https://github.com/openjdk/jdk21u/compare/jdk-21.0.3+2...jdk-21.0.3+3
 
-From the command line if you have a clone of our repository you can use
+From the command-line if you have a clone of our repository you can use
 these comments to get the list of commits and or the full source code diff:
 
-```
+```sh
 git log jdk-21.0.3+2_adopt..jdk-21.0.3+3_adopt
 git diff jdk-21.0.3+2_adopt..jdk-21.0.3+3_adopt
 ```
@@ -99,7 +99,7 @@ to those referenced earlier it can be downloaded from:
 
 ## Why am I not seeing early access builds for the latest release?
 
-There is one caveat for producing early access builds using this procedure. 
+There is one caveat for producing early access builds using this procedure.
 The process relies on the party maintaining the upstream version to perform
 the tagging in public.  If those tags aren't visible in public, we have no
 way to build from an invisible tag.  This usually happens for the time
@@ -115,7 +115,6 @@ regularly from the head of the repository.  In these cases if you need to
 know what is in each version you can determine which git SHA we built from
 using corresponding SBoM artefact that can be downloaded from the API by
 replacing “/jdk/” with “/sbom/” in the above URL.  For example:
-
 
 - https://api.adoptium.net/v3/binary/version/jdk-22+36-ea-beta/linux/aarch64/sbom/hotspot/normal/eclipse?project=jdk
 

--- a/content/blog/early-access-builds-feb2024/index.md
+++ b/content/blog/early-access-builds-feb2024/index.md
@@ -99,12 +99,12 @@ using similar queries to those referenced earlier it can be downloaded from:
 
 ## Why am I not seeing early access builds for the latest release?
 
-There is one caveat for producing early access builds using this procedure. 
+There is one caveat for producing early access builds using this procedure.
 The process relies on the party maintaining the upstream version to perform
 the tagging in public.  If those tags aren't visible in public, we have no
 way to build from an invisible tag.  This usually happens for the time
 period when new major JDK versions get released and subsequent quarterly
-security updates for those releases are being handled (usually by Oracle). 
+security updates for those releases are being handled (usually by Oracle).
 For example between JDK `22` GA, `22.0.1` and `22.0.2` releases.  There are
 no public tags available for early access tags `jdk-22.0.1+1`,
 `jdk-22.0.1+2` and so on.  Should processes change some time in the future

--- a/content/blog/early-access-builds-feb2024/index.md
+++ b/content/blog/early-access-builds-feb2024/index.md
@@ -92,8 +92,8 @@ Since we are now producing builds explicitly from the tags, this means that
 when a build is declared as a release candidate for an upcoming release, you
 can download a Temurin early access build corresponding to that version on
 each of our platforms.  At the time of writing jdk-22+36 has been declared
-release candidate 1 for the upcoming JDK22 release so using similar queries
-to those referenced earlier it can be downloaded from:
+release candidate 2 (jdk-22+35 was RC1) for the upcoming JDK22 release so
+using similar queries to those referenced earlier it can be downloaded from:
 
 - https://api.adoptium.net/v3/binary/version/jdk-22+36-ea-beta/linux/aarch64/jdk/hotspot/normal/adoptium
 

--- a/content/blog/early-access-builds-feb2024/index.md
+++ b/content/blog/early-access-builds-feb2024/index.md
@@ -30,8 +30,8 @@ these builds.
 
 By building and providing these early access builds from tags instead of the
 head of the default branch we can more easily work with the upstream openjdk
-project to identify the contents of a specific builds when providing but
-reports and reproduductions.
+project to identify the contents of a specific builds when providing bug
+reports and reproductions.
 
 ## How do I get the early access builds?
 
@@ -46,7 +46,7 @@ redirects:
 
 At the time of writing this will provide you with jdk-21.0.3+3.  If you want
 a previous build to compare with then you can specify a particular version
-directly when calling them API, for example this will retrieve jdk-21.0.3+2
+directly when calling the API, for example this will retrieve jdk-21.0.3+2
 from the previous week:
 
 - https://api.adoptium.net/v3/binary/version/jdk-21.0.3+2-ea-beta/linux/aarch64/jdk/hotspot/normal/adoptium
@@ -99,14 +99,23 @@ to those referenced earlier it can be downloaded from:
 
 ## Why am I not seeing early access builds for the latest release?
 
-There is one caveat for early access builds is that for the few months after
-a new major release comes out when it is typically managed by Oracle there
-are no regular tags produced so we cannot use the processes described in
-this article to build from tags.  In this case we will revert to building
+There is one caveat for producing early access builds using this procedure. 
+The process relies on the party maintaining the upstream version to perform
+the tagging in public.  If those tags aren't visible in public, we have no
+way to build from an invisible tag.  This usually happens for the time
+period when new major JDK versions get released and subsequent quarterly
+security updates for those releases are being handled by Oracle.  For
+example between JDK `22` GA, `22.0.1` and `22.0.2` releases.  There are no
+public tags available for early access tags `jdk-22.0.1+1`, `jdk-22.0.1+2`
+and so on.  Should processes change some time in the future we'd of course
+provide early access builds using the same process as for other releases.
+
+In the case of no publicly visible tags, however, we will revert to building
 regularly from the head of the repository.  In these cases if you need to
-know what is in each version you can determine which github SHA we built
-from using corresponding SBoM that can be downloaded from the API by
+know what is in each version you can determine which git SHA we built from
+using corresponding SBoM artefact that can be downloaded from the API by
 replacing “/jdk/” with “/sbom/” in the above URL.  For example:
+
 
 - https://api.adoptium.net/v3/binary/version/jdk-22+36-ea-beta/linux/aarch64/sbom/hotspot/normal/eclipse?project=jdk
 

--- a/content/blog/early-access-builds/index.md
+++ b/content/blog/early-access-builds/index.md
@@ -6,6 +6,11 @@ description: Adoptium are publishing early access "tagged" builds instead of nig
 tags:
   - temurin
 ---
+
+NOTE: Much of the information in this blog has been superceded by
+https://adoptium.net/blog/2024/02/early-access-builds-feb2024 - please refer
+to that one instead
+
 In addition to the generally available release builds of all currently supported
 versions of openjdk (Currently 8, 11, 17 and 20) Temurin also publishes "nightly"
 development builds of all of those streams as well as the upcoming releases (JDK21/22


### PR DESCRIPTION
# Description of change

New blog post with information about the early access builds which are now available for all JDK lines.

Notes for reviewers:
- I'm not sure if I like the wording in the "Why am I not seeing early access builds for the latest release?" section so if anyone has suggestions please say so. I will probably update this blog with some examples of this when JDK22 comes out since the current examples in that section are based on the RC build.
- I haven't included the github actions example code from the earlier blog here
- The JDK22 release candidate information is useful at this point in time but I suspect it may be worth removing it later one JDK22 has gone GA. As an alternative we could have a separate blog article about the release candidate availability.
- While this article says we have status posts to slack, we do not go into any further detail - if anyone things we should provide more then feel free to suggest it, although the format of the messages has changed in the last few weeks and so I didn't want to say any more on this.
- The examples on how to compare the contents of different builds uses `_adopt` suffix tags in our mirror repositories but does not explicitly explain what those are.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
