### PR TITLE
Fix/issues 2668 correct pb with release notes given version

### DIFF
--- a/src/__fixtures__/hooks.tsx
+++ b/src/__fixtures__/hooks.tsx
@@ -278,6 +278,7 @@ export const createRandomTemurinReleases = (installer): TemurinReleases => ({
   release_link: new URL('https://release_link_mock'),
   source_url: new URL('https://source_url_mock'),
   release_notes: true,
+  release_notes_name: 'release_name_mock',
   timestamp: new Date(Date.UTC(2020, 0, 1)),
   platforms: {
     'platform_mock': {

--- a/src/__fixtures__/hooks.tsx
+++ b/src/__fixtures__/hooks.tsx
@@ -278,7 +278,7 @@ export const createRandomTemurinReleases = (installer): TemurinReleases => ({
   release_link: new URL('https://release_link_mock'),
   source_url: new URL('https://source_url_mock'),
   release_notes: true,
-  release_notes_name: 'release_name_mock',
+  release_notes_name: 'release_notes_name_mock',
   timestamp: new Date(Date.UTC(2020, 0, 1)),
   platforms: {
     'platform_mock': {

--- a/src/components/TemurinArchiveTable/__tests__/__snapshots__/TemurinArchiveTable.test.tsx.snap
+++ b/src/components/TemurinArchiveTable/__tests__/__snapshots__/TemurinArchiveTable.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`TemurinArchiveTable component > renders correctly 1`] = `
               <p>
                 <a
                   class="link-light"
-                  href="/temurin/release-notes?version=release_name_mock"
+                  href="/temurin/release-notes?version=release_notes_name_mock"
                 >
                   <svg
                     fill="currentColor"
@@ -310,7 +310,7 @@ exports[`TemurinArchiveTable component > renders correctly 1`] = `
               <p>
                 <a
                   class="link-light"
-                  href="/temurin/release-notes?version=release_name_mock"
+                  href="/temurin/release-notes?version=release_notes_name_mock"
                 >
                   <svg
                     fill="currentColor"

--- a/src/components/TemurinArchiveTable/index.tsx
+++ b/src/components/TemurinArchiveTable/index.tsx
@@ -44,8 +44,8 @@ const TemurinArchiveTable = ({results, updatePage}) => {
                                                 {release.source_url &&
                                                     <p><a href={release.source_url} className="link-light"><FaDownload /> <Trans>Source Code Archive</Trans></a></p>
                                                 }
-                                                {release.release_notes &&
-                                                    <p><Link to={`/temurin/release-notes?version=${release.release_name}`} className="link-light"><MdNotes /> <Trans>Release Notes</Trans></Link></p>
+                                                {release.release_notes && 
+                                                    <p><Link to={`/temurin/release-notes?version=${release.release_notes_name}`} className="link-light"><MdNotes /> <Trans>Release Notes</Trans></Link></p>
                                                 }
                                             </div>
                                         </td>

--- a/src/hooks/__tests__/__snapshots__/fetchTemurinArchive.test.tsx.snap
+++ b/src/hooks/__tests__/__snapshots__/fetchTemurinArchive.test.tsx.snap
@@ -83,6 +83,7 @@ exports[`getAssetsForVersion > returns valid JSON - with release notes 1`] = `
       "release_link": "https://release_link_mock/",
       "release_name": "0.0.0",
       "release_notes": true,
+      "release_notes_name": "release_name_mock",
       "timestamp": "2020-01-01T00:00:00.000Z",
     },
   ],

--- a/src/hooks/fetchTemurinArchive.tsx
+++ b/src/hooks/fetchTemurinArchive.tsx
@@ -66,6 +66,7 @@ function renderReleases(pkgs: MockTemurinFeatureReleaseAPI[], pagecount: number,
         }
         if (aRelease.release_notes) {
           release.release_notes = true;
+          release.release_notes_name = aRelease.release_name;
         }
 
         if (releaseType === 'ga' && !['INSTALLER', 'JDK', 'JRE'].includes(binary_type)) {
@@ -126,6 +127,7 @@ export interface TemurinReleases {
     };
   };
   release_notes?: boolean;
+  release_notes_name?: string;
 }
 
 interface ReleaseAsset {


### PR DESCRIPTION
Correct problem with Release Note version passed as parameter from the Archive Page.

History: We have created a function to display the name of the Release properly. But for the release note URL we have to use the original name returned by the API.


- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
