### PR TITLE
Add logo Styleguide Link to the Branding Documentation

### DIFF
--- a/src/pages/__tests__/__snapshots__/docs.test.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/docs.test.tsx.snap
@@ -1015,6 +1015,12 @@ exports[`Docs page > renders correctly 1`] = `
                     </a>
                     <a
                       class="list-group-item list-group-item-action"
+                      href="/docs/logo-styleguide/"
+                    >
+                      footer.logo.and.artwork
+                    </a>
+                    <a
+                      class="list-group-item list-group-item-action"
                       href="/temurin/buttons"
                     >
                       docs.download.buttons

--- a/src/pages/docs.tsx
+++ b/src/pages/docs.tsx
@@ -118,6 +118,7 @@ const DocumentationPage = ({ data }) => {
               links={[
                 { name: t('docs.brand.guidelines', 'Brand Guidelines'), link: 'https://www.eclipse.org/org/artwork/guidelines/adoptium-brand-guidelines.pdf' },
                 { name: t('docs.google.slide.template', 'Google Slide Template'), link: 'https://docs.google.com/presentation/d/1ChGhqZrAHCdk5S2Ii5s5RROng1saTaTtjZzsxWJ_MPA/copy' },
+                { name: t('footer.logo.and.artwork', 'Logo and Artwork'), link: '/docs/logo-styleguide/' },
                 { name: t('docs.download.buttons', 'Download Buttons'), link: '/temurin/buttons' },
                 { name: t('docs.marketing.criteria', 'Marketing Criteria'), link: '/docs/marketing-criteria' }
               ]}


### PR DESCRIPTION
# Description of change

This PR is related to the issue adoptium/adoptium.net-redesign#1122 

_Add logo Styleguide Link to the Branding Documentation_

![image](https://github.com/adoptium/adoptium.net/assets/3774556/510786be-e3d5-46e5-a59b-526d71cc47ca)


## Checklist
- [X] `npm test` passes
