### PR TITLE
Add riscv64 entry in Architecture selector

### DIFF
--- a/src/pages/__tests__/__snapshots__/marketplace.test.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/marketplace.test.tsx.snap
@@ -169,6 +169,11 @@ exports[`Marketplace page > renders correctly 1`] = `
             ppc64le
           </option>
           <option
+            value="riscv64"
+          >
+            riscv64
+          </option>
+          <option
             value="s390x"
           >
             s390x

--- a/src/pages/temurin/__tests__/__snapshots__/releases.test.tsx.snap
+++ b/src/pages/temurin/__tests__/__snapshots__/releases.test.tsx.snap
@@ -146,6 +146,11 @@ exports[`Releases page > renders correctly 1`] = `
             ppc64le
           </option>
           <option
+            value="riscv64"
+          >
+            riscv64
+          </option>
+          <option
             value="s390x"
           >
             s390x

--- a/src/util/defaults.tsx
+++ b/src/util/defaults.tsx
@@ -1,7 +1,7 @@
 // This file is used to store defaults which can be accessed by other Javascript/Typescript functions
 
 export const oses = ['Linux', 'alpine-linux', 'Windows', 'mac', 'AIX', 'Solaris'];
-export const arches = ['x64', 'x86', 'aarch64', 's390x', 'ppc64le', 'ppc64', 'arm', 'sparcv9'];
+export const arches = ['x64', 'x86', 'aarch64', 's390x', 'ppc64le', 'ppc64', 'arm', 'sparcv9' ,'riscv64'];
 export const packageTypes = ['JDK', 'JRE'];
 
 let defaultPackageType = 'jdk';


### PR DESCRIPTION
# Description of change
Add riscv64 entry in Architecture selector
## Checklist
- [X] `npm test` passes
