### PR TITLE
Remove banner for April 2024 releases

### DIFF
--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -13,10 +13,10 @@ Sep 2024
 
 | Java 22
 | Mar 2024
-| 19 Mar 2024 +
-[.small]#jdk-22+36#
-| 16 Apr 2024 +
-[.small]#jdk-22.0.1#
+| 19 Apr 2024 +
+[.small]#jdk-22+0.1+9#
+| 16 Jul 2024 +
+[.small]#jdk-22.0.2#
 | Sep 2023
 
 | Java 21 (LTS)
@@ -50,26 +50,26 @@ Sep 2024
 
 | Java 17 (LTS)
 | Sep 2021
-| 23 Jan 2024 +
-[.small]#jdk-17.0.10+7#
-| 16 Apr 2024 +
-[.small]#jdk-17.0.11#
+| 18 Apr 2024 +
+[.small]#jdk-17.0.11+9#
+| 16 Jul 2024 +
+[.small]#jdk-17.0.12#
 | At least Oct 2027
 
 | Java 11 (LTS)
 | Sep 2018
-| 22 Jan 2024 +
-[.small]#jdk-11.0.22+7#
-| 16 Apr 2024 +
-[.small]#jdk-11.0.23#
+| 18 Apr 2024 +
+[.small]#jdk-11.0.23+9#
+| 16 Jul 2024 +
+[.small]#jdk-11.0.24#
 | At least Oct 2027
 
 | Java 8 (LTS)
 | Mar 2014
-| 19 Jan 2024 +
-[.small]#jdk8u402b06#
-| 16 Apr 2024 +
-[.small]#jdk8u412#
+| 18 Apr 2024 +
+[.small]#jdk8u412-b08#
+| 16 Jul 2024 +
+[.small]#jdk8u422#
 | At least Nov 2026
 
 |===

--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -1,17 +1,20 @@
 import React from 'react';
 
 const Banner = () => {
+  return null;
+
   // The following is an example that can be used for future banner alert
   // Comment Out The Above Line ( return null ; ) and uncomment the below
 
-  return (
-    <div className="alert text-white alert-dismissible fade show mb-0 text-center" style={{ backgroundColor: '#ff1464' }} role="alert">
-    <strong className='p-1'>16th April 2024:</strong>
-        We are creating the April 2024 PSU binaries for Eclipse Temurin 8u412, 11.0.23, 17.0.11, 21.0.3 and 22.0.1<br/>
-        You can track progress <a className='alert-link p-1 text-white' href="https://github.com/adoptium/temurin/issues/38">by platform</a>.
-      <button type="button" className="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-    </div>
-  );
+  //  return (
+  //    <div className="alert text-white alert-dismissible fade show mb-0 text-center" style={{ backgroundColor: '#ff1464' }} role="alert">
+  //    <strong className='p-1'>20th March 2024:</strong>
+  //        We are creating the March 2024 PSU binaries for Eclipse Temurin 22.0.0<br/>
+  //        You can track progress <a className='alert-link p-1 text-white' href="https://github.com/adoptium/temurin/issues/35">by platform</a>.
+  //     <button type="button" className="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+  //    </div>
+  //  );
+
 };
 
 export default Banner;


### PR DESCRIPTION
Noting that this will likely be replaced soon with [a banner containing a link to the Temurin secure dev case study](https://github.com/adoptium/adoptium.net-redesign/issues/1109)

# Description of change
<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
