### PR TITLE
Add Temurin case-study banner and as part of the documentation

### DIFF
--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -1,20 +1,20 @@
 import React from 'react';
 
 const Banner = () => {
-  return null;
+  // return null;
 
   // The following is an example that can be used for future banner alert
   // Comment Out The Above Line ( return null ; ) and uncomment the below
 
-  //  return (
-  //    <div className="alert text-white alert-dismissible fade show mb-0 text-center" style={{ backgroundColor: '#ff1464' }} role="alert">
-  //    <strong className='p-1'>20th March 2024:</strong>
-  //        We are creating the March 2024 PSU binaries for Eclipse Temurin 22.0.0<br/>
-  //        You can track progress <a className='alert-link p-1 text-white' href="https://github.com/adoptium/temurin/issues/35">by platform</a>.
-  //     <button type="button" className="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-  //    </div>
-  //  );
-
+   return (
+     <div className="alert text-white alert-dismissible fade show mb-0 text-center" style={{ backgroundColor: '#ff1464' }} role="alert">
+       <strong className='p-1'>26th March 2024:</strong>
+       Case Study: Building the World's Most Secure OpenJDK Distribution<br/>
+       Find out how the Eclipse Foundation and Adoptium Working Group are pioneering software supply chain security with Eclipse Temurin.<br/>
+       <a className='alert-link p-1 text-white' href="https://outreach.eclipse.foundation/adoptium-temurin-supply-chain-security?utm_campaign=Temurin%20Case%20Study&utm_source=website&utm_medium=adoptium%20docs">Read more</a>
+       <button type="button" className="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+     </div>
+   );
 };
 
 export default Banner;

--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -9,7 +9,7 @@ const Banner = () => {
    return (
      <div className="alert text-white alert-dismissible fade show mb-0 text-center" style={{ backgroundColor: '#ff1464' }} role="alert">
        <strong className='p-1'>Case Study: Building the World's Most Secure OpenJDK Distribution</strong><br/>
-       Find out how the Eclipse Foundation and Adoptium Working Group are pioneering software supply chain security with Eclipse Temurin. 
+       Find out how the Eclipse Foundation and Adoptium Working Group are pioneering software supply chain security with Eclipse Temurin: 
        <a className='alert-link p-1 text-white' href="https://outreach.eclipse.foundation/adoptium-temurin-supply-chain-security?utm_campaign=Temurin%20Case%20Study&utm_source=website&utm_medium=adoptium%20docs">Download now</a>
        <button type="button" className="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
      </div>

--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -8,10 +8,9 @@ const Banner = () => {
 
    return (
      <div className="alert text-white alert-dismissible fade show mb-0 text-center" style={{ backgroundColor: '#ff1464' }} role="alert">
-       <strong className='p-1'>26th March 2024:</strong>
-       Case Study: Building the World's Most Secure OpenJDK Distribution<br/>
-       Find out how the Eclipse Foundation and Adoptium Working Group are pioneering software supply chain security with Eclipse Temurin.<br/>
-       <a className='alert-link p-1 text-white' href="https://outreach.eclipse.foundation/adoptium-temurin-supply-chain-security?utm_campaign=Temurin%20Case%20Study&utm_source=website&utm_medium=adoptium%20docs">Read more</a>
+       <strong className='p-1'>26th March 2024</strong> - Case Study: Building the World's Most Secure OpenJDK Distribution<br/>
+       Find out how the Eclipse Foundation and Adoptium Working Group are pioneering software supply chain security with Eclipse Temurin. 
+       <a className='alert-link p-1 text-white' href="https://outreach.eclipse.foundation/adoptium-temurin-supply-chain-security?utm_campaign=Temurin%20Case%20Study&utm_source=website&utm_medium=adoptium%20docs">Download now</a>
        <button type="button" className="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
      </div>
    );

--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -8,7 +8,7 @@ const Banner = () => {
 
    return (
      <div className="alert text-white alert-dismissible fade show mb-0 text-center" style={{ backgroundColor: '#ff1464' }} role="alert">
-       <strong className='p-1'>26th March 2024</strong> - Case Study: Building the World's Most Secure OpenJDK Distribution<br/>
+       <strong className='p-1'>Case Study: Building the World's Most Secure OpenJDK Distribution</strong><br/>
        Find out how the Eclipse Foundation and Adoptium Working Group are pioneering software supply chain security with Eclipse Temurin. 
        <a className='alert-link p-1 text-white' href="https://outreach.eclipse.foundation/adoptium-temurin-supply-chain-security?utm_campaign=Temurin%20Case%20Study&utm_source=website&utm_medium=adoptium%20docs">Download now</a>
        <button type="button" className="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>

--- a/src/pages/__tests__/__snapshots__/docs.test.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/docs.test.tsx.snap
@@ -579,6 +579,28 @@ exports[`Docs page > renders correctly 1`] = `
                         />
                       </svg>
                     </a>
+                    <a
+                      class="list-group-item list-group-item-action"
+                      href="https://outreach.eclipse.foundation/adoptium-temurin-supply-chain-security?utm_campaign=Temurin%20Case%20Study&utm_source=website&utm_medium=adoptium%20docs"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      docs.temurin.security.case.study
+                       
+                      <svg
+                        fill="currentColor"
+                        height="13"
+                        stroke="currentColor"
+                        stroke-width="0"
+                        viewBox="0 0 512 512"
+                        width="13"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                        />
+                      </svg>
+                    </a>
                   </div>
                 </div>
               </div>

--- a/src/pages/docs.tsx
+++ b/src/pages/docs.tsx
@@ -78,7 +78,8 @@ const DocumentationPage = ({ data }) => {
               links={[
                 { name: t('docs.secure.software.pratices', 'Secure Software Practices'), link: '/docs/secure-software' },
                 { name: t('docs.slsa.secure.supply.chain', 'SLSA Secure Supply Chain'), link: '/docs/slsa' },
-                { name: t('docs.vulnerability.reporting', 'Vulnerability Reporting'), link: 'https://github.com/adoptium/adoptium/security/policy' }
+                { name: t('docs.vulnerability.reporting', 'Vulnerability Reporting'), link: 'https://github.com/adoptium/adoptium/security/policy' },
+                { name: t('docs.temurin.security.case.study', 'Temurin Security Case Study'), link: 'https://outreach.eclipse.foundation/adoptium-temurin-supply-chain-security?utm_campaign=Temurin%20Case%20Study&utm_source=website&utm_medium=adoptium%20docs' }
               ]}
             />
             <DocumentationCard


### PR DESCRIPTION
Add Temurin case-study banner and as part of the documentation, related to adoptium/adoptium.net-redesign#1109 



## Checklist
- [X] `npm test` passes
- [X] documentation is changed or added (if applicable)
