### PR TITLE
Update support-table.adoc - fix Java 22 end date typo

### DIFF
--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -17,7 +17,7 @@ Sep 2024
 [.small]#jdk-22+0.1+9#
 | 16 Jul 2024 +
 [.small]#jdk-22.0.2#
-| Sep 2023
+| Sep 2024
 
 | Java 21 (LTS)
 | Sep 2023


### PR DESCRIPTION
Change 2023 to 2024.

# Description of change
<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
