### PR TITLE
Bump date-fns to 3.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@react-icons/all-files": "^4.1.0",
         "axios": "^1.6.8",
         "bootstrap": "^5.3.3",
-        "date-fns": "^2.30.0",
+        "date-fns": "^3.6.0",
         "flexsearch": "^0.7.43",
         "gatsby": "^5.13.4",
         "gatsby-adapter-netlify": "^1.1.4",
@@ -10275,18 +10275,12 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -14866,6 +14860,21 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/gatsby/node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
     },
     "node_modules/gatsby/node_modules/decode-uri-component": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@react-icons/all-files": "^4.1.0",
     "axios": "^1.6.8",
     "bootstrap": "^5.3.3",
-    "date-fns": "^2.30.0",
+    "date-fns": "^3.6.0",
     "flexsearch": "^0.7.43",
     "gatsby": "^5.13.4",
     "gatsby-adapter-netlify": "^1.1.4",

--- a/src/components/VersionSelector/index.tsx
+++ b/src/components/VersionSelector/index.tsx
@@ -6,6 +6,7 @@ import queryString from 'query-string';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV3';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker';
+import * as Locales from 'date-fns/locale';
 
 import { setURLParam } from '../../util/setURLParam';
 
@@ -40,7 +41,7 @@ const VersionSelector = ({updater, releaseType, Table}) => {
 
   // import the correct date locale for the language
   if (language !== 'en') {
-    locale = require(`date-fns/locale/${language}`).default;
+    locale = Locales[language] ?? Locales[language.substring(0, 2)] ?? Locales.enUS
   }
 
   let selectedVersion = defaultVersion

--- a/src/components/VersionSelector/index.tsx
+++ b/src/components/VersionSelector/index.tsx
@@ -3,7 +3,7 @@ import { useStaticQuery, graphql } from 'gatsby';
 import { Trans, useI18next } from 'gatsby-plugin-react-i18next'
 import { useLocation } from '@gatsbyjs/reach-router';
 import queryString from 'query-string';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV3';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker';
 
@@ -40,7 +40,7 @@ const VersionSelector = ({updater, releaseType, Table}) => {
 
   // import the correct date locale for the language
   if (language !== 'en') {
-    locale = require(`date-fns/locale/${language}/index.js`);
+    locale = require(`date-fns/locale/${language}`).default;
   }
 
   let selectedVersion = defaultVersion


### PR DESCRIPTION
# Description of change
Finally updated version of the library to 3.6.0: date-fns :sweat_smile: 


## Checklist
- [X] `npm test` passes
