### PR TITLE
Fix JDK21 dates on support page

### DIFF
--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -21,10 +21,10 @@ Sep 2024
 
 | Java 21 (LTS)
 | Sep 2023
-| 24 Jan 2024 +
-[.small]#jdk-21.0.2+13#
 | 16 Apr 2024 +
-[.small]#jdk-21.0.3#
+[.small]#jdk-21.0.3+9#
+| 16 Jul 2024 +
+[.small]#jdk-21.0.4#
 | At least Dec 2029
 
 | Java 20


### PR DESCRIPTION
# Description of change

JDK21 dates were not updated as part of https://github.com/adoptium/adoptium.net/pull/2807

This PR fixes that.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
