### PR TITLE
Correct date of Adoptium news

### DIFF
--- a/src/components/AdoptiumNews/index.tsx
+++ b/src/components/AdoptiumNews/index.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import moment from 'moment';
-import { Trans } from 'gatsby-plugin-react-i18next';
+import { Trans, useI18next } from 'gatsby-plugin-react-i18next';
 import LinkText from '../LinkText'
 
 const AdoptiumNews = () => {
+
+    const { language } = useI18next();
 
     // NOTES: 
     // - You can add a <callToActionLink /> tag to create a link in the body
@@ -26,7 +27,7 @@ const AdoptiumNews = () => {
             <div className='container py-5'>
                 <h2 className='text-pink'>{adoptiumNews.title}</h2>
                 <div>
-                    {adoptiumNews.date && <p className='m-0 fw-bold'>{moment(adoptiumNews.date).format('D MMMM YYYY')}</p>}
+                    {adoptiumNews.date && <p className='m-0 fw-bold'>{(adoptiumNews.date.toLocaleDateString(language))}</p>}
                     <p className='text-muted lh-sm'>
                         <Trans 
                             defaults={adoptiumNews.body} 

--- a/src/components/AdoptiumNews/index.tsx
+++ b/src/components/AdoptiumNews/index.tsx
@@ -2,21 +2,34 @@ import React from 'react';
 import { Trans, useI18next } from 'gatsby-plugin-react-i18next';
 import LinkText from '../LinkText'
 
+// NOTES: 
+// - You can add a <callToActionLink /> tag to create a link in the body
+// - Dates must be with the format: "YYYY-MM-dd"
+const adoptiumNews = {
+    title: "Adoptium Summit 2024", 
+    body: "Be a part of the first-ever Adoptium Summit on September, 10.<br/>Connect with peers to exchange knowledge on Temurin, AQAvit and other Adoptium's projects.<br/><callToActionLink>Register here</callToActionLink>", 
+    callToActionLink: 'https://www.eclipse.org/events/2024/adoptium-summit/', 
+    date: new Date('2024-09-10'),
+    startDisplayAt: new Date('2024-05-15'),
+    stopDisplayAfter: new Date('2024-06-30'),
+}
+
+const eventDateOptions = { year: 'numeric', month: 'long', day: 'numeric' };
+
 const AdoptiumNews = () => {
 
     const { language } = useI18next();
 
-    // NOTES: 
-    // - You can add a <callToActionLink /> tag to create a link in the body
-    // - Dates must be with the format: "YYYY-MM-dd"
-
-    const adoptiumNews = {
-        title: "Adoptium Summit 2024", 
-        body: "Be a part of the first-ever Adoptium Summit on September, 10.<br/>Connect with peers to exchange knowledge on Temurin, AQAvit and other Adoptium's projects.<br/><callToActionLink>Register here</callToActionLink>", 
-        callToActionLink: 'https://www.eclipse.org/events/2024/adoptium-summit/', 
-        date: new Date('2024-09-10'),
-        startDisplayAt: new Date('2024-05-15'),
-        stopDisplayAfter: new Date('2024-06-30'),
+    var eventDateUTC:Date|null = null;
+    if(adoptiumNews.date) {
+        eventDateUTC = new Date(Date.UTC(
+            adoptiumNews.date.getUTCFullYear(), 
+            adoptiumNews.date.getUTCMonth(),
+            adoptiumNews.date.getUTCDate(), 
+            adoptiumNews.date.getUTCHours(),
+            adoptiumNews.date.getUTCMinutes(), 
+            adoptiumNews.date.getUTCSeconds()));
+    
     }
 
     const now = Date.now();
@@ -27,7 +40,7 @@ const AdoptiumNews = () => {
             <div className='container py-5'>
                 <h2 className='text-pink'>{adoptiumNews.title}</h2>
                 <div>
-                    {adoptiumNews.date && <p className='m-0 fw-bold'>{(adoptiumNews.date.toLocaleDateString(language))}</p>}
+                    {eventDateUTC && <p className='m-0 fw-bold'>{(eventDateUTC.toLocaleDateString(language, eventDateOptions))}</p>}
                     <p className='text-muted lh-sm'>
                         <Trans 
                             defaults={adoptiumNews.body} 

--- a/src/components/AdoptiumNews/index.tsx
+++ b/src/components/AdoptiumNews/index.tsx
@@ -14,7 +14,12 @@ const adoptiumNews = {
     stopDisplayAfter: new Date('2024-06-30'),
 }
 
-const eventDateOptions = { year: 'numeric', month: 'long', day: 'numeric' };
+const eventDateOptions = { 
+    year: 'numeric', 
+    month: 'long', 
+    day: 'numeric', 
+    timeZone: "UTC"
+}
 
 const AdoptiumNews = () => {
 


### PR DESCRIPTION
# Description of change
Fix problem with displayed date. 
Whatever is the given date, use the UTC for rendering to have the same date for every body.

- [X ] `npm test` passes
