### PR TITLE
correct end of support date for jdk-11

### DIFF
--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -62,7 +62,7 @@ Sep 2024
 [.small]#jdk-11.0.23+9#
 | 16 Jul 2024 +
 [.small]#jdk-11.0.24#
-| At least Oct 2027
+| At least Oct 2024
 
 | Java 8 (LTS)
 | Mar 2014


### PR DESCRIPTION
Hey guys


# Description of change
Isn't it supposed to be Oct 24 instead of Oct 27? \
If i am wrong sorry for bothering. \
At least also RH hast full support only until Oct 24.
-Mario
