### PR TITLE
[Issue-2791] Add link submit news

### DIFF
--- a/src/pages/__tests__/__snapshots__/news.test.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/news.test.tsx.snap
@@ -250,6 +250,15 @@ exports[`News page > renders correctly 1`] = `
           >
             View all
           </a>
+          |
+          <a
+            class="px-2"
+            href="https://newsroom.eclipse.org/node/add/news"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Submit news
+          </a>
         </div>
         <div
           class="col-md-1"
@@ -389,6 +398,15 @@ exports[`News page > renders spinner when news not loaded 1`] = `
             target="_blank"
           >
             View all
+          </a>
+          |
+          <a
+            class="px-2"
+            href="https://newsroom.eclipse.org/node/add/news"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Submit news
           </a>
         </div>
         <div

--- a/src/pages/news.tsx
+++ b/src/pages/news.tsx
@@ -53,6 +53,8 @@ const NewsPage = (): JSX.Element => {
                 />
               : null}           
               <a href="https://newsroom.eclipse.org/eclipse/community-news" target='_blank' rel='noreferrer' className='px-2'>View all</a>
+              |
+              <a href="https://newsroom.eclipse.org/node/add/news" target='_blank' rel='noreferrer' className='px-2'>Submit news</a>
             </div>
             <div className='col-md-1' />
             <div className='col-md-6'>


### PR DESCRIPTION
# Description of change
Changes are related to request adoptium/adoptium.net-redesign#1111 to add a "Submit news" link.

![image](https://github.com/adoptium/adoptium.net/assets/3774556/cdbf8788-1f5d-45f2-abf1-345fbbf58663)


## Checklist
- [X] `npm test` passes
