### PR TITLE
[3016] Assume that there are EA versions for versions between 16 and …

### DIFF
--- a/src/components/VersionSelector/__tests__/__snapshots__/VersionSelector.test.tsx.snap
+++ b/src/components/VersionSelector/__tests__/__snapshots__/VersionSelector.test.tsx.snap
@@ -27,42 +27,42 @@ exports[`VersionSelector > updates the number of builds and build date when the 
       [36m<option[39m
         [33mvalue[39m=[32m"23"[39m
       [36m>[39m
-        [0m23[0m
+        [0m23 - EA[0m
       [36m</option>[39m
       [36m<option[39m
         [33mvalue[39m=[32m"22"[39m
       [36m>[39m
-        [0m22[0m
+        [0m22 - EA[0m
       [36m</option>[39m
       [36m<option[39m
         [33mvalue[39m=[32m"21"[39m
       [36m>[39m
-        [0m21[0m
+        [0m21 - EA[0m
       [36m</option>[39m
       [36m<option[39m
         [33mvalue[39m=[32m"20"[39m
       [36m>[39m
-        [0m20[0m
+        [0m20 - EA[0m
       [36m</option>[39m
       [36m<option[39m
         [33mvalue[39m=[32m"19"[39m
       [36m>[39m
-        [0m19[0m
+        [0m19 - EA[0m
       [36m</option>[39m
       [36m<option[39m
         [33mvalue[39m=[32m"18"[39m
       [36m>[39m
-        [0m18[0m
+        [0m18 - EA[0m
       [36m</option>[39m
       [36m<option[39m
         [33mvalue[39m=[32m"17"[39m
       [36m>[39m
-        [0m17[0m
+        [0m17 - EA[0m
       [36m</option>[39m
       [36m<option[39m
         [33mvalue[39m=[32m"16"[39m
       [36m>[39m
-        [0m16[0m
+        [0m16 - EA[0m
       [36m</option>[39m
       [36m<option[39m
         [33mvalue[39m=[32m"2"[39m

--- a/src/components/VersionSelector/__tests__/__snapshots__/VersionSelector.test.tsx.snap
+++ b/src/components/VersionSelector/__tests__/__snapshots__/VersionSelector.test.tsx.snap
@@ -22,17 +22,12 @@ exports[`VersionSelector > updates the number of builds and build date when the 
       [36m<option[39m
         [33mvalue[39m=[32m"2"[39m
       [36m>[39m
-        [0m2 - EA[0m
+        [0m2[0m
       [36m</option>[39m
       [36m<option[39m
         [33mvalue[39m=[32m"1"[39m
       [36m>[39m
         [0m1 - LTS[0m
-      [36m</option>[39m
-      [36m<option[39m
-        [33mvalue[39m=[32m"2"[39m
-      [36m>[39m
-        [0m2[0m
       [36m</option>[39m
     [36m</select>[39m
   [36m</div>[39m

--- a/src/components/VersionSelector/__tests__/__snapshots__/VersionSelector.test.tsx.snap
+++ b/src/components/VersionSelector/__tests__/__snapshots__/VersionSelector.test.tsx.snap
@@ -20,6 +20,51 @@ exports[`VersionSelector > updates the number of builds and build date when the 
       [33mstyle[39m=[32m"max-width: 10em;"[39m
     [36m>[39m
       [36m<option[39m
+        [33mvalue[39m=[32m"24"[39m
+      [36m>[39m
+        [0m24 - EA[0m
+      [36m</option>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"23"[39m
+      [36m>[39m
+        [0m23[0m
+      [36m</option>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"22"[39m
+      [36m>[39m
+        [0m22[0m
+      [36m</option>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"21"[39m
+      [36m>[39m
+        [0m21[0m
+      [36m</option>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"20"[39m
+      [36m>[39m
+        [0m20[0m
+      [36m</option>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"19"[39m
+      [36m>[39m
+        [0m19[0m
+      [36m</option>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"18"[39m
+      [36m>[39m
+        [0m18[0m
+      [36m</option>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"17"[39m
+      [36m>[39m
+        [0m17[0m
+      [36m</option>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"16"[39m
+      [36m>[39m
+        [0m16[0m
+      [36m</option>[39m
+      [36m<option[39m
         [33mvalue[39m=[32m"2"[39m
       [36m>[39m
         [0m2[0m

--- a/src/components/VersionSelector/index.tsx
+++ b/src/components/VersionSelector/index.tsx
@@ -81,7 +81,7 @@ const VersionSelector = ({updater, releaseType, Table}) => {
   const versionsToDisplay = [...versions]
 
   if(releaseType === "ea") {
-    // if releaseType is ea, add missing versions up to mostRecentFeatureVersion (as EA for the last)
+    // if releaseType is "ea", add missing "ea" versions up to mostRecentFeatureVersion
     const range = (start: number, stop: number, step: number) =>
       Array.from({ length: (stop - start) / step + 1 }, (_, i) => start + i * step);
 
@@ -96,7 +96,7 @@ const VersionSelector = ({updater, releaseType, Table}) => {
           node: {
             id: version,
             version: version,
-            label: `${version}${version === mostRecentFeatureVersion ? ' - EA' : ''}`
+            label: `${version} - EA`
           }
         }
         versionsToDisplay.push(v)

--- a/src/components/VersionSelector/index.tsx
+++ b/src/components/VersionSelector/index.tsx
@@ -78,6 +78,35 @@ const VersionSelector = ({updater, releaseType, Table}) => {
     udateNumBuilds(number);
   }, []);
 
+  const versionsToDisplay = [...versions]
+
+  if(releaseType === "ea") {
+    // if releaseType is ea, add missing versions up to mostRecentFeatureVersion (as EA for the last)
+    const range = (start: number, stop: number, step: number) =>
+      Array.from({ length: (stop - start) / step + 1 }, (_, i) => start + i * step);
+
+    // https://github.com/adoptium/adoptium.net/issues/3016
+    // johnoliver: "assume that there are EA versions for versions between 16 and most_recent_feature_version"
+    const sixteenToLastEA = range(16, mostRecentFeatureVersion, 1);
+
+    sixteenToLastEA.forEach(version => {
+      if(versionsToDisplay.findIndex(v => v.node.version === version) < 0) {
+        // this version number is missing, append to the version list
+        const v = {
+          node: {
+            id: version,
+            version: version,
+            label: `${version}${version === mostRecentFeatureVersion ? ' - EA' : ''}`
+          }
+        }
+        versionsToDisplay.push(v)
+      }
+    })
+
+    // sort by version DESC
+    versionsToDisplay.sort((v1, v2) => v2.node.version - v1.node.version)
+  }
+
   return (
     <>
       <p className='text-center'>
@@ -86,12 +115,7 @@ const VersionSelector = ({updater, releaseType, Table}) => {
       <div className="input-group p-3 d-flex justify-content-center">
         <label className="px-2 fw-bold" htmlFor="version"><Trans>Version</Trans></label>
         <select data-testid="version-filter" aria-label="version-filter" id="version-filter" onChange={(e) => setVersion(e.target.value)} value={version} className="form-select form-select-sm" style={{ maxWidth: '10em' }}>
-            {/* if releaseType is ea add another option */}
-            {releaseType === "ea" && (
-              <option key={mostRecentFeatureVersion} value={mostRecentFeatureVersion}>{`${mostRecentFeatureVersion} - EA`}</option>
-            )}
-            {/* loop through versions array from graphql */}
-            {versions.map(
+            {versionsToDisplay.map(
               (version, i): number | JSX.Element => version && (
                 <option key={version.node.id} value={version.node.version}>{version.node.label}</option>
               )

--- a/src/pages/temurin/__tests__/__snapshots__/nightly.test.tsx.snap
+++ b/src/pages/temurin/__tests__/__snapshots__/nightly.test.tsx.snap
@@ -114,42 +114,42 @@ exports[`Temurin Nightly page > renders correctly 1`] = `
         <option
           value="23"
         >
-          23
+          23 - EA
         </option>
         <option
           value="22"
         >
-          22
+          22 - EA
         </option>
         <option
           value="21"
         >
-          21
+          21 - EA
         </option>
         <option
           value="20"
         >
-          20
+          20 - EA
         </option>
         <option
           value="19"
         >
-          19
+          19 - EA
         </option>
         <option
           value="18"
         >
-          18
+          18 - EA
         </option>
         <option
           value="17"
         >
-          17
+          17 - EA
         </option>
         <option
           value="16"
         >
-          16
+          16 - EA
         </option>
         <option
           value="2"

--- a/src/pages/temurin/__tests__/__snapshots__/nightly.test.tsx.snap
+++ b/src/pages/temurin/__tests__/__snapshots__/nightly.test.tsx.snap
@@ -107,6 +107,51 @@ exports[`Temurin Nightly page > renders correctly 1`] = `
         style="max-width: 10em;"
       >
         <option
+          value="24"
+        >
+          24 - EA
+        </option>
+        <option
+          value="23"
+        >
+          23
+        </option>
+        <option
+          value="22"
+        >
+          22
+        </option>
+        <option
+          value="21"
+        >
+          21
+        </option>
+        <option
+          value="20"
+        >
+          20
+        </option>
+        <option
+          value="19"
+        >
+          19
+        </option>
+        <option
+          value="18"
+        >
+          18
+        </option>
+        <option
+          value="17"
+        >
+          17
+        </option>
+        <option
+          value="16"
+        >
+          16
+        </option>
+        <option
           value="2"
         >
           2

--- a/src/pages/temurin/__tests__/__snapshots__/nightly.test.tsx.snap
+++ b/src/pages/temurin/__tests__/__snapshots__/nightly.test.tsx.snap
@@ -109,17 +109,12 @@ exports[`Temurin Nightly page > renders correctly 1`] = `
         <option
           value="2"
         >
-          2 - EA
+          2
         </option>
         <option
           value="1"
         >
           1 - LTS
-        </option>
-        <option
-          value="2"
-        >
-          2
         </option>
       </select>
     </div>

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -28,7 +28,7 @@ vi.mock('gatsby', async () => {
       version: 1,
     },
     mostRecentFeatureVersion: {
-      version: 2,
+      version: 24,
     },
     allVersions: {
       edges: [


### PR DESCRIPTION
# Description of change
This is a PR to answer to the issue adoptium/adoptium.net-redesign#1090 
It is a proposition to deal with missing version numbers returned by the API.

"_assume that there are EA versions for versions between 16 and most_recent_feature_version_"

Check here: https://deploy-preview-3059--eclipsefdn-adoptium.netlify.app/fr/temurin/nightly/?version=23


## Checklist
- [X] `npm test` passes
