### PR TITLE
Add contributing ref to Agile Guidelines

### DIFF
--- a/content/asciidoc-pages/contributing/index.adoc
+++ b/content/asciidoc-pages/contributing/index.adoc
@@ -41,7 +41,11 @@ For more information, please see the https://www.eclipse.org/projects/handbook/#
 
 == Submitting a contribution to Adoptium
 
-After signing the ECA, you can propose contributions by sending pull requests (PRs) through GitHub.
+After signing the ECA, you can propose contributions by sending pull requests (PRs) through GitHub. Pull requests
+should be accompanied by a GitHub issue that documents the problem or feature that the change is addressing. The
+Eclipse Adoptium project uses the Agile methodology for planning and developing fixes and new features, the
+https://github.com/adoptium/adoptium/wiki/Adoptium-Agile-Guidelines[Adoptium Agile Guidelines] documents what is
+required for GitHub issues and contributions.
 
 **Note:** Assume we are contributing to the `aqa-tests` repo
 


### PR DESCRIPTION
# Description of change
Add link to https://github.com/adoptium/adoptium/wiki/Adoptium-Agile-Guidelines in Contributing page

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
