### PR TITLE
Update support platforms table for jdk-23

### DIFF
--- a/content/asciidoc-pages/supported-platforms/index.adoc
+++ b/content/asciidoc-pages/supported-platforms/index.adoc
@@ -14,7 +14,7 @@ icon:check[] - Supported, icon:docker[] - Docker image available, icon:times[] -
 |===
 .2+h|Operating System 5+h|Eclipse Temurin Version h|
 
-{nbsp} 8 h|11 h|17 h|21 h|22
+{nbsp} 8 h|11 h|17 h|21 h|23
 6+h| Windows (x64)
 | Windows Server 2022 | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
 | Windows Server 2019 | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]| icon:check[] icon:docker[]
@@ -72,6 +72,7 @@ icon:check[] - Supported, icon:docker[] - Docker image available, icon:times[] -
 | Ubuntu 20.04 | icon:times[] footnote:nojit[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[] | icon:check[] icon:docker[]
 
 6+h| Linux (riscv64) footnote:glibc231[These builds should work on any distribution with glibc version 2.31 or higher.]
+| Ubuntu 24.04 | icon:times[] | icon:times[] | icon:times[] | icon:check[] | icon:check[]
 | Ubuntu 22.04 | icon:times[] | icon:times[] | icon:times[] | icon:check[] | icon:check[]
 | Ubuntu 20.04 | icon:times[] | icon:times[] | icon:times[] | icon:check[] | icon:check[]
 


### PR DESCRIPTION
# Description of change
Update support platforms table:
- replace 22 with 23
- add Ubuntu 24.04 for riscv64

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
