### PR TITLE
Add macOS 15 to supported platforms table

### DIFF
--- a/content/asciidoc-pages/supported-platforms/index.adoc
+++ b/content/asciidoc-pages/supported-platforms/index.adoc
@@ -81,12 +81,13 @@ icon:check[] - Supported, icon:docker[] - Docker image available, icon:times[] -
 | Ubuntu 20.04 | icon:times[] | icon:times[] | icon:times[] | icon:check[] | icon:check[]
 
 6+h| macOS (x64)
+| macOS 15 | icon:check[] | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 | macOS 14 | icon:times[] | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 | macOS 13 | icon:check[] | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 | macOS 12 | icon:check[] | icon:check[] | icon:check[] | icon:check[] | icon:check[]
-| macOS 11 | icon:check[] | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 
 6+h| macOS (Apple Silicon)
+| macOS 15 | icon:check[] | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 | macOS 14 | icon:times[] | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 | macOS 13 | icon:times[] | icon:check[] | icon:check[] | icon:check[] | icon:check[]
 | macOS 12 | icon:times[] | icon:check[] | icon:check[] | icon:check[] | icon:check[]


### PR DESCRIPTION
As per our policy, we only support the the 4 most recent versions

# Description of change
<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
