### PR TITLE
Enable asciidoc for more directories

### DIFF
--- a/content/asciidoc-pages/README.md
+++ b/content/asciidoc-pages/README.md
@@ -2,7 +2,7 @@
 
 Most static pages on this site are written as [asciidoc](https://asciidoctor.org/docs/what-is-asciidoc/) pages. These are similar to Markdown in format but give us more flexibility.
 
-The directory layout of these files is very important as it determines the path to the file in the site. For example a documnet in `/foo/bar/index.adoc` will be served up as `/foo/bar` on the site. You could also store the same document as `/foo/bar.adoc` but we generally discourage this as we need a parent folder to store localised versions of the page.
+The directory layout of these files is very important as it determines the path to the file in the site. For example a document in `/foo/bar/index.adoc` will be served up as `/foo/bar` on the site. You could also store the same document as `/foo/bar.adoc` but we generally discourage this as we need a parent folder to store localised versions of the page.
 
 ```tree
 .

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -85,19 +85,19 @@ const config: GatsbyConfig = {
         },
         pages: [
           {
-            matchPath: '/:lang?/docs/:uid',
-            getLanguageFromPath: true
-          },
-          {
-            matchPath: '/:lang?/temurin/commercial-support/',
-            getLanguageFromPath: true
-          },
-          {
             matchPath: '/:lang?/about/',
             getLanguageFromPath: true
           },
           {
+            matchPath: '/:lang?/docs/:uid',
+            getLanguageFromPath: true
+          },
+          {
             matchPath: '/:lang?/installation/:uid',
+            getLanguageFromPath: true
+          },
+          {
+            matchPath: '/:lang?/temurin/:uid',
             getLanguageFromPath: true
           }
         ]


### PR DESCRIPTION
In order to enable more asciidoc directories to be translated, we have to add it in the config.

After we'll be able to merge the german translation in this PR:
ref https://github.com/adoptium/adoptium.net/pull/3058


## Checklist
- [X] `npm test` passes
- [X] documentation is changed or added (if applicable)
