### PR TITLE
January 2025 release banner

### DIFF
--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
 
 const Banner = () => {
-  return null;
+  // return null;
 
   // The following is an example that can be used for future banner alert
   // Comment Out The Above Line ( return null ; ) and uncomment the below
 
-  // return (
-  //   <div className="alert text-white alert-dismissible fade show mb-0 text-center" style={{ backgroundColor: '#ff1464' }} role="alert">
-  //     <strong className='p-1'>16th July 2024:</strong>
-  //        We are creating the July 2024 PSU binaries for Eclipse Temurin 8u422, 11.0.24, 17.0.12, 21.0.4 and 22.0.2<br/>
-  //        You can track progress <a className='alert-link p-1 text-white' href="https://github.com/adoptium/temurin/issues/49">by platform</a>.
-  //     <button type="button" className="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-  //   </div>
-  // );
+  return (
+    <div className="alert text-white alert-dismissible fade show mb-0 text-center" style={{ backgroundColor: '#ff1464' }} role="alert">
+      <strong className='p-1'>21st January 2025:</strong>
+         We are creating the January 2025 PSU binaries for Eclipse Temurin 8u442, 11.0.26, 17.0.14, 21.0.6 and 23.0.2<br/>
+         You can track progress <a className='alert-link p-1 text-white' href="https://github.com/adoptium/temurin/issues/67">by platform</a>.
+      <button type="button" className="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+  );
 };
 
 export default Banner;


### PR DESCRIPTION

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)


