### PR TITLE
added Spanish translation

### DIFF
--- a/content/asciidoc-pages/installation/linux/index.es.adoc
+++ b/content/asciidoc-pages/installation/linux/index.es.adoc
@@ -1,0 +1,135 @@
+= Linux (RPM/DEB/APK) installer packages
+:page-authors: rocketxz
+:toc:
+:icons: font
+
+Los paquetes RPM, DEB y APK de Eclipse Temurin se encuentran disponibles para instalación en su distribución de Linux preferida.
+
+[NOTA]
+====
+Consulte link:/supported-platforms[Plataformas Compatibles] para consultar la lista de instaladores oficialmente compatibles según la distribución/versión de Linux. Para otras distribuciones/versiones, se brinda soporte en función de la disponibilidad de recursos.
+====
+
+[TIP]
+====
+Tenga en cuenta que, en la mayoría de los sistemas Linux, se requieren privilegios de superusuario para instalar paquetes como Temurin. Para garantizar la ejecución exitosa de los comandos a continuación, es posible que deba anteponerles `sudo`. Además, al agregar el repositorio, considere usar `sudo tee` para evitar posibles problemas de permisos. Por ejemplo:
+[source, bash]
+----
+echo "deb [arch=amd64] https://some.repository.url focal main" | sudo tee /etc/apt/sources.list.d/adoptium.list > /dev/null
+----
+Al utilizar `sudo tee`, puede escribir la entrada del repositorio en el archivo correspondiente con privilegios elevados, evitando errores de permisos de escritura. Esto garantiza un proceso de instalación sin contratiempos.
+====
+
+== Nombres de paquetes de Eclipse Temurin
+
+Se utiliza el siguiente esquema de nombres:
+
+....
+temurin-<versión>-jdk
+por ejemplo: temurin-17-jdk o temurin-8-jdk
+....
+
+== Instalación de paquetes DEB en Debian o Ubuntu
+
+. Asegúrese de que los paquetes necesarios estén instalados:
++
+[source, bash]
+----
+apt install -y wget apt-transport-https gpg
+----
++
+. Descargue la clave GPG de Eclipse Adoptium:
++
+[source, bash]
+----
+wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/adoptium.gpg > /dev/null
+----
++
+. Configure el repositorio apt de Eclipse Adoptium. Para consultar la lista completa de versiones compatibles, revise el listado en el árbol de directorios en https://packages.adoptium.net/ui/native/deb/dists/.
++
+[source, bash]
+----
+echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
+----
+CONSEJO: Para Linux Mint (basado en Ubuntu), debe reemplazar `VERSION_CODENAME` con `UBUNTU_CODENAME`.
++
+. Instale la versión de Temurin que necesite:
++
+[source, bash]
+----
+apt update # actualice si no lo ha hecho ya
+apt install temurin-17-jdk
+----
+
+== Instrucciones para CentOS/RHEL/Fedora
+
+. Agregue el repositorio RPM a `/etc/yum.repos.d/adoptium.repo`, asegurándose de cambiar el nombre de la distribución si no está utilizando CentOS/RHEL/Fedora. Para consultar la lista completa de versiones compatibles, revise el listado en el árbol de directorios en https://packages.adoptium.net/ui/native/rpm/.
++
+[source, bash]
+----
+# Descomente y cambie el nombre de la distribución si no está utilizando CentOS/RHEL/Fedora
+# DISTRIBUTION_NAME=centos
+
+cat <<EOF > /etc/yum.repos.d/adoptium.repo
+[Adoptium]
+name=Adoptium
+baseurl=https://packages.adoptium.net/artifactory/rpm/${DISTRIBUTION_NAME:-$(. /etc/os-release; echo $ID)}/\$releasever/\$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public
+EOF
+----
++
+. Instale la versión de Temurin que necesite utilizando `dnf`:
++
+[source, bash]
+----
+dnf install temurin-17-jdk
+----
+Alternativamente, si está utilizando `yum`:
++
+[source, bash]
+----
+yum install temurin-17-jdk
+----
+
+== Instrucciones para openSUSE/SLES
+
+. Importe el repositorio RPM de la siguiente manera. Los RPM también están disponibles para SLES 12 y 15. Para consultar la lista completa de versiones compatibles, revise el listado en https://packages.adoptium.net/ui/native/rpm/. Los repositorios pueden funcionar con otras versiones, pero no están garantizados y no han sido probados.
++
+[source, bash]
+----
+zypper ar -f https://packages.adoptium.net/artifactory/rpm/opensuse/$(. /etc/os-release; echo $VERSION_ID)/$(uname -m) adoptium
+----
++
+. Instale la versión de Temurin que necesite:
++
+[source, bash]
+----
+zypper install temurin-17-jdk
+----
+
+== Instrucciones para Alpine Linux
+
+. Descargue la clave RSA de Eclipse Adoptium:
++
+[source, bash]
+----
+wget -O /etc/apk/keys/adoptium.rsa.pub https://packages.adoptium.net/artifactory/api/security/keypair/public/repositories/apk
+----
++
+. Configure el repositorio APK de Eclipse Adoptium:
++
+[source, bash]
+----
+echo 'https://packages.adoptium.net/artifactory/apk/alpine/main' >> /etc/apk/repositories
+----
++
+. Instale la versión de Temurin que necesite:
++
+[source, bash]
+----
+apk add temurin-17-jdk
+----
+
+Por favor, reporte cualquier problema en https://github.com/adoptium/installer/issues.


### PR DESCRIPTION
# Description of change

## What does this PR do?
This PR adds a new translation of the "[Linux (RPM/DEB/APK) installer packages](link-to-original-page)" page into Spanish. The translation covers all sections, including installation instructions for Debian/Ubuntu, CentOS/RHEL/Fedora, openSUSE/SLES, and Alpine Linux, ensuring consistency with the original English documentation.

## Why is this change important?
This change makes the installation instructions accessible to Spanish-speaking users, improving the inclusivity and usability of the documentation for a broader audience.

## Additional context
- The translation follows the original structure and formatting (AsciiDoc) to maintain consistency.
- All technical terms and commands have been preserved, with only the explanatory text translated.
- The translation has been reviewed for accuracy and clarity.

