### PR TITLE
Add Temurin availability information for JDK24 and 25

### DIFF
--- a/content/asciidoc-pages/support/_partials/support-table.adoc
+++ b/content/asciidoc-pages/support/_partials/support-table.adoc
@@ -3,6 +3,18 @@
 
 | Java Version  | First Availability | Latest Release | Next Release Due | End of Availability ^[1]^
 
+| Java 25 (LTS)
+| Expected Sep 2025
+| Not available
+| Expected Sep 2025
+| Expected at least Sep 2031
+
+| Java 24
+| Expected Mar 2025
+| Not available
+| Expected Mar 2025
+| Expected Sep 2025
+
 | Java 23
 | Sep 2024
 | 15 Oct 2024 +


### PR DESCRIPTION
These are expected future releases of Temurin 24 and Temurin 25 LTS.

# Description of change

The Temurin 24 non-LTS is replaced by the Temurin 25 (LTS) in September 2025. The Temurin 25 and of availability follows the expected six year period of prior LTS releases.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
