### PR TITLE
Clarify jdk21u replacement

### DIFF
--- a/content/asciidoc-pages/docs/reproducible-verification-builds/reproduce-linux-x64/index.adoc
+++ b/content/asciidoc-pages/docs/reproducible-verification-builds/reproduce-linux-x64/index.adoc
@@ -185,7 +185,7 @@ export PATH=<bootjdk>/bin:$PATH
 
 . Clone required upstream OpenJDK source
 +
-Replace jdk21u with the upstream release being built
+Replace "jdk21u" in the command below with the upstream release being built
 +
 [source,]
 ----


### PR DESCRIPTION
# Description of change

Clarifying that "jdk21u" refers to the string in the command, not the directory produced by the scripts. It would be very sad if someone removed the jdk21u directory which contains the custom installation of gcc produced by the scripts, which would take a long time to regenerate.

(This almost happened to us when following the instructions due to the unclear wording.)

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
